### PR TITLE
fix invariant bug

### DIFF
--- a/test/Handler.sol
+++ b/test/Handler.sol
@@ -57,7 +57,8 @@ contract Handler is CommonBase, StdCheats, StdUtils {
   }
 
   function _useActor(AddressSet storage _set, uint256 _randomActorSeed) internal view returns (address) {
-    return _set.rand(_randomActorSeed);
+    address _actor = _set.rand(_randomActorSeed);
+    vm.assume(_actor != address(0));
   }
 
   function _mintToken(address _to, uint256 _amount) internal {


### PR DESCRIPTION
found a failing invariant sequence, turns out it was because the handler was making a delegation from `address(0)`. it's corrected by safely assuming that actor will never be `address(0)`