### PR TITLE
Update DeployL2GovToken.s.sol

### DIFF
--- a/script/DeployL2GovToken.s.sol
+++ b/script/DeployL2GovToken.s.sol
@@ -24,7 +24,7 @@ contract DeployL2GovToken is Script {
   }
 
   function run() public virtual {
-    vm.startBroadcast(deployer);
+    vm.startBroadcast(msg.sender);
     L2GovToken token = new L2GovToken();
     console.log("L2GovToken impl:\t", address(token));
     proxy = L2GovToken(


### PR DESCRIPTION
Use `msg.sender` instead of undeclared variable `deployer` in the deployment script.

Without this, I got a confusing error from foundry:

`No associated wallet for addresses: [0x0000000000000000000000000000000000000000].`