### PR TITLE
votableSupply: `getVotableSupply` / `getPastVotableSupply` and tests

### DIFF
--- a/src/IVotesPartialDelegation.sol
+++ b/src/IVotesPartialDelegation.sol
@@ -36,6 +36,11 @@ interface IVotesPartialDelegation is IERC6372 {
   event DelegateVotesChanged(address indexed delegate, uint256 previousVotes, uint256 newVotes);
 
   /**
+   * @dev Emitted when the voteable supply changes.
+   */
+  event VotableSupplyChanged(uint256 previousSupply, uint256 newSupply);
+
+  /**
    * @dev Returns the current amount of votes that `account` has.
    */
   function getVotes(address account) external view returns (uint256);
@@ -57,12 +62,12 @@ interface IVotesPartialDelegation is IERC6372 {
   function getPastTotalSupply(uint256 timepoint) external view returns (uint256);
 
   /**
-   * @dev Return the latest voteable supply
+   * @dev Return the latest voteable supply.
    */
   function getVoteableSupply() external view returns (uint256);
 
   /**
-   * @dev Return the voteable supply at a gievn block number
+   * @dev Return the voteable supply at a given block number.
    */
   function getPastVoteableSupply(uint256 timepoint) external view returns (uint256);
 

--- a/src/IVotesPartialDelegation.sol
+++ b/src/IVotesPartialDelegation.sol
@@ -4,13 +4,13 @@ pragma solidity 0.8.26;
 import {IERC6372} from "@openzeppelin/contracts/interfaces/IERC6372.sol";
 
 struct PartialDelegation {
-  address _delegatee;
-  uint96 _numerator;
+    address _delegatee;
+    uint96 _numerator;
 }
 
 struct DelegationAdjustment {
-  address _delegatee;
-  uint208 _amount;
+    address _delegatee;
+    uint208 _amount;
 }
 
 /**
@@ -18,57 +18,92 @@ struct DelegationAdjustment {
  * @custom:security-contact security@voteagora.com
  */
 interface IVotesPartialDelegation is IERC6372 {
-  /**
-   * @dev The signature used has expired.
-   */
-  error VotesExpiredSignature(uint256 expiry);
+    /**
+     * @dev The signature used has expired.
+     */
+    error VotesExpiredSignature(uint256 expiry);
 
-  /**
-   * @dev Emitted when an account changes their delegate.
-   */
-  event DelegateChanged(
-    address indexed delegator, PartialDelegation[] oldDelegatees, PartialDelegation[] newDelegatees
-  );
+    /**
+     * @dev Emitted when an account changes their delegate.
+     */
+    event DelegateChanged(
+        address indexed delegator,
+        PartialDelegation[] oldDelegatees,
+        PartialDelegation[] newDelegatees
+    );
 
-  /**
-   * @dev Emitted when a token transfer or delegate change results in changes to a delegate's number of voting units.
-   */
-  event DelegateVotesChanged(address indexed delegate, uint256 previousVotes, uint256 newVotes);
+    /**
+     * @dev Emitted when a token transfer or delegate change results in changes to a delegate's number of voting units.
+     */
+    event DelegateVotesChanged(
+        address indexed delegate,
+        uint256 previousVotes,
+        uint256 newVotes
+    );
 
-  /**
-   * @dev Returns the current amount of votes that `account` has.
-   */
-  function getVotes(address account) external view returns (uint256);
+    /**
+     * @dev Returns the current amount of votes that `account` has.
+     */
+    function getVotes(address account) external view returns (uint256);
 
-  /**
-   * @dev Returns the amount of votes that `account` had at a specific moment in the past. If the `clock()` is
-   * configured to use block numbers, this will return the value at the end of the corresponding block.
-   */
-  function getPastVotes(address account, uint256 timepoint) external view returns (uint256);
+    /**
+     * @dev Returns the amount of votes that `account` had at a specific moment in the past. If the `clock()` is
+     * configured to use block numbers, this will return the value at the end of the corresponding block.
+     */
+    function getPastVotes(
+        address account,
+        uint256 timepoint
+    ) external view returns (uint256);
 
-  /**
-   * @dev Returns the total supply of votes available at a specific moment in the past. If the `clock()` is
-   * configured to use block numbers, this will return the value at the end of the corresponding block.
-   *
-   * NOTE: This value is the sum of all available votes, which is not necessarily the sum of all delegated votes.
-   * Votes that have not been delegated are still part of total supply, even though they would not participate in a
-   * vote.
-   */
-  function getPastTotalSupply(uint256 timepoint) external view returns (uint256);
+    /**
+     * @dev Returns the total supply of votes available at a specific moment in the past. If the `clock()` is
+     * configured to use block numbers, this will return the value at the end of the corresponding block.
+     *
+     * NOTE: This value is the sum of all available votes, which is not necessarily the sum of all delegated votes.
+     * Votes that have not been delegated are still part of total supply, even though they would not participate in a
+     * vote.
+     */
+    function getPastTotalSupply(
+        uint256 timepoint
+    ) external view returns (uint256);
 
-  /**
-   * @dev Returns the delegate that `account` has chosen.
-   * Removed: This function is incompatible with partial delegation, which allows for multiple delegates per account.
-   */
-  //   function delegates(address account) external view returns (address);
+    /**
+     * @dev Return the latest voteable supply
+     */
+    function getVoteableSupply() external view returns (uint256);
 
-  /**
-   * @dev Delegates votes from the sender to `delegatee`.
-   */
-  function delegate(address delegatee) external;
+    /**
+     * @dev Return the voteable supply at a gievn block number
+     */
+    function getPastVoteableSupply(
+        uint256 timepoint
+    ) external view returns (uint256);
 
-  /**
-   * @dev Delegates votes from signer to `delegatee`.
-   */
-  function delegateBySig(address delegatee, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) external;
+    /**
+     * @dev Return the number of active delegates
+     */
+    function getActiveDelgateesCount() external view returns (uint256);
+
+    /**
+     * @dev Returns the delegate that `account` has chosen.
+     * Removed: This function is incompatible with partial delegation, which allows for multiple delegates per account.
+     */
+    //   function delegates(address account) external view returns (address);
+
+    /**
+     * @dev Delegates votes from the sender to `delegatee`.
+     */
+    function delegate(address delegatee) external;
+
+    /**
+     * @dev Delegates votes from signer to `delegatee`.
+     */
+    function delegateBySig(
+        address delegatee,
+        uint256 nonce,
+        uint256 expiry,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
 }

--- a/src/IVotesPartialDelegation.sol
+++ b/src/IVotesPartialDelegation.sol
@@ -4,13 +4,13 @@ pragma solidity 0.8.26;
 import {IERC6372} from "@openzeppelin/contracts/interfaces/IERC6372.sol";
 
 struct PartialDelegation {
-    address _delegatee;
-    uint96 _numerator;
+  address _delegatee;
+  uint96 _numerator;
 }
 
 struct DelegationAdjustment {
-    address _delegatee;
-    uint208 _amount;
+  address _delegatee;
+  uint208 _amount;
 }
 
 /**
@@ -18,87 +18,67 @@ struct DelegationAdjustment {
  * @custom:security-contact security@voteagora.com
  */
 interface IVotesPartialDelegation is IERC6372 {
-    /**
-     * @dev The signature used has expired.
-     */
-    error VotesExpiredSignature(uint256 expiry);
+  /**
+   * @dev The signature used has expired.
+   */
+  error VotesExpiredSignature(uint256 expiry);
 
-    /**
-     * @dev Emitted when an account changes their delegate.
-     */
-    event DelegateChanged(
-        address indexed delegator,
-        PartialDelegation[] oldDelegatees,
-        PartialDelegation[] newDelegatees
-    );
+  /**
+   * @dev Emitted when an account changes their delegate.
+   */
+  event DelegateChanged(
+    address indexed delegator, PartialDelegation[] oldDelegatees, PartialDelegation[] newDelegatees
+  );
 
-    /**
-     * @dev Emitted when a token transfer or delegate change results in changes to a delegate's number of voting units.
-     */
-    event DelegateVotesChanged(
-        address indexed delegate,
-        uint256 previousVotes,
-        uint256 newVotes
-    );
+  /**
+   * @dev Emitted when a token transfer or delegate change results in changes to a delegate's number of voting units.
+   */
+  event DelegateVotesChanged(address indexed delegate, uint256 previousVotes, uint256 newVotes);
 
-    /**
-     * @dev Returns the current amount of votes that `account` has.
-     */
-    function getVotes(address account) external view returns (uint256);
+  /**
+   * @dev Returns the current amount of votes that `account` has.
+   */
+  function getVotes(address account) external view returns (uint256);
 
-    /**
-     * @dev Returns the amount of votes that `account` had at a specific moment in the past. If the `clock()` is
-     * configured to use block numbers, this will return the value at the end of the corresponding block.
-     */
-    function getPastVotes(
-        address account,
-        uint256 timepoint
-    ) external view returns (uint256);
+  /**
+   * @dev Returns the amount of votes that `account` had at a specific moment in the past. If the `clock()` is
+   * configured to use block numbers, this will return the value at the end of the corresponding block.
+   */
+  function getPastVotes(address account, uint256 timepoint) external view returns (uint256);
 
-    /**
-     * @dev Returns the total supply of votes available at a specific moment in the past. If the `clock()` is
-     * configured to use block numbers, this will return the value at the end of the corresponding block.
-     *
-     * NOTE: This value is the sum of all available votes, which is not necessarily the sum of all delegated votes.
-     * Votes that have not been delegated are still part of total supply, even though they would not participate in a
-     * vote.
-     */
-    function getPastTotalSupply(
-        uint256 timepoint
-    ) external view returns (uint256);
+  /**
+   * @dev Returns the total supply of votes available at a specific moment in the past. If the `clock()` is
+   * configured to use block numbers, this will return the value at the end of the corresponding block.
+   *
+   * NOTE: This value is the sum of all available votes, which is not necessarily the sum of all delegated votes.
+   * Votes that have not been delegated are still part of total supply, even though they would not participate in a
+   * vote.
+   */
+  function getPastTotalSupply(uint256 timepoint) external view returns (uint256);
 
-    /**
-     * @dev Return the latest voteable supply
-     */
-    function getVoteableSupply() external view returns (uint256);
+  /**
+   * @dev Return the latest voteable supply
+   */
+  function getVoteableSupply() external view returns (uint256);
 
-    /**
-     * @dev Return the voteable supply at a gievn block number
-     */
-    function getPastVoteableSupply(
-        uint256 timepoint
-    ) external view returns (uint256);
+  /**
+   * @dev Return the voteable supply at a gievn block number
+   */
+  function getPastVoteableSupply(uint256 timepoint) external view returns (uint256);
 
-    /**
-     * @dev Returns the delegate that `account` has chosen.
-     * Removed: This function is incompatible with partial delegation, which allows for multiple delegates per account.
-     */
-    //   function delegates(address account) external view returns (address);
+  /**
+   * @dev Returns the delegate that `account` has chosen.
+   * Removed: This function is incompatible with partial delegation, which allows for multiple delegates per account.
+   */
+  //   function delegates(address account) external view returns (address);
 
-    /**
-     * @dev Delegates votes from the sender to `delegatee`.
-     */
-    function delegate(address delegatee) external;
+  /**
+   * @dev Delegates votes from the sender to `delegatee`.
+   */
+  function delegate(address delegatee) external;
 
-    /**
-     * @dev Delegates votes from signer to `delegatee`.
-     */
-    function delegateBySig(
-        address delegatee,
-        uint256 nonce,
-        uint256 expiry,
-        uint8 v,
-        bytes32 r,
-        bytes32 s
-    ) external;
+  /**
+   * @dev Delegates votes from signer to `delegatee`.
+   */
+  function delegateBySig(address delegatee, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) external;
 }

--- a/src/IVotesPartialDelegation.sol
+++ b/src/IVotesPartialDelegation.sol
@@ -36,7 +36,7 @@ interface IVotesPartialDelegation is IERC6372 {
   event DelegateVotesChanged(address indexed delegate, uint256 previousVotes, uint256 newVotes);
 
   /**
-   * @dev Emitted when the voteable supply changes.
+   * @dev Emitted when the votable supply changes.
    */
   event VotableSupplyChanged(uint256 previousSupply, uint256 newSupply);
 
@@ -62,14 +62,14 @@ interface IVotesPartialDelegation is IERC6372 {
   function getPastTotalSupply(uint256 timepoint) external view returns (uint256);
 
   /**
-   * @dev Return the latest voteable supply.
+   * @dev Return the latest votable supply.
    */
-  function getVoteableSupply() external view returns (uint256);
+  function getVotableSupply() external view returns (uint256);
 
   /**
-   * @dev Return the voteable supply at a given block number.
+   * @dev Return the votable supply at a given block number.
    */
-  function getPastVoteableSupply(uint256 timepoint) external view returns (uint256);
+  function getPastVotableSupply(uint256 timepoint) external view returns (uint256);
 
   /**
    * @dev Returns the delegate that `account` has chosen.

--- a/src/IVotesPartialDelegation.sol
+++ b/src/IVotesPartialDelegation.sol
@@ -80,11 +80,6 @@ interface IVotesPartialDelegation is IERC6372 {
     ) external view returns (uint256);
 
     /**
-     * @dev Return the number of active delegates
-     */
-    function getActiveDelgateesCount() external view returns (uint256);
-
-    /**
      * @dev Returns the delegate that `account` has chosen.
      * Removed: This function is incompatible with partial delegation, which allows for multiple delegates per account.
      */

--- a/src/VotesPartialDelegationUpgradeable.sol
+++ b/src/VotesPartialDelegationUpgradeable.sol
@@ -46,7 +46,6 @@ abstract contract VotesPartialDelegationUpgradeable is
     mapping(address account => PartialDelegation[]) _delegatees;
     mapping(address delegatee => Checkpoints.Trace208) _delegateCheckpoints;
     Checkpoints.Trace208 _totalCheckpoints;
-    // Add checkpoint for votableSupply
     Checkpoints.Trace208 _votableSupplyCheckpoints;
   }
 
@@ -388,8 +387,7 @@ abstract contract VotesPartialDelegationUpgradeable is
       // check sorting and uniqueness
       if (i == 0 && _newDelegations[i]._delegatee == address(0)) {
         // zero delegation is allowed if in 0th position
-      }
-      else if (_newDelegations[i]._delegatee <= _lastDelegatee) {
+      } else if (_newDelegations[i]._delegatee <= _lastDelegatee) {
         revert DuplicateOrUnsortedDelegatees(_newDelegations[i]._delegatee);
       }
 
@@ -415,8 +413,7 @@ abstract contract VotesPartialDelegationUpgradeable is
 
   /**
    * @dev Transfers, mints, or burns voting units. To register a mint, `from` should be zero. To register a burn, `to`
-   * should be zero. Total supply of voting units will be adjusted with mints and burns. Votable supply will also stay
-   * updated.
+   * should be zero. Total and votable supplies will be adjusted with mints and burns.
    */
   function _transferVotingUnits(address from, address to, uint256 amount) internal virtual {
     // skip from==to no-op, as the math would require special handling

--- a/src/VotesPartialDelegationUpgradeable.sol
+++ b/src/VotesPartialDelegationUpgradeable.sol
@@ -46,10 +46,11 @@ abstract contract VotesPartialDelegationUpgradeable is
     mapping(address account => PartialDelegation[]) _delegatees;
     mapping(address delegatee => Checkpoints.Trace208) _delegateCheckpoints;
     Checkpoints.Trace208 _totalCheckpoints;
+    // Add checkpoint for voteableSupply
+    Checkpoints.Trace208 _voteableSupplyCheckpoints;
+    // Keep track of active delegates for voteableSupply calulations
+    mapping(address => bool) _activeDelegatees; 
   }
-  // Keep track of the delegated delegates
-  address[] private _allDelegatees;
-
   enum Op {
     ADD,
     SUBTRACT
@@ -185,16 +186,11 @@ abstract contract VotesPartialDelegationUpgradeable is
  *
  * NOTE: This value is the sum of all delegated votes at the current block.
  */
-  function getVoteableSupply() public view returns (uint256) {
+function getVoteableSupply() public view returns (uint256) {
     VotesPartialDelegationStorage storage $ = _getVotesPartialDelegationStorage();
-    uint256 voteableSupply = 0;
-
-    // Iterate through all delegatees and sum up their votes
-    for (uint256 i = 0; i < _allDelegatees.length; i++) {
-        voteableSupply += $._delegateCheckpoints[_allDelegatees[i]].latest();
-    }
-
-    return voteableSupply;
+    uint256 voteableSupply = $._voteableSupplyCheckpoints.latest();
+    uint256 totalSupply = _getTotalSupply();
+    return voteableSupply > totalSupply ? totalSupply : voteableSupply;
 }
 
 /**
@@ -219,13 +215,7 @@ abstract contract VotesPartialDelegationUpgradeable is
         revert ERC5805FutureLookup(timepoint, currentTimepoint);
     }
 
-    uint256 voteableSupply = 0;
-
-    for (uint256 i = 0; i < _allDelegatees.length; i++) {
-        voteableSupply += $._delegateCheckpoints[_allDelegatees[i]].upperLookupRecent(SafeCast.toUint48(timepoint));
-    }
-
-    return voteableSupply;
+    return $._voteableSupplyCheckpoints.upperLookupRecent(SafeCast.toUint48(timepoint));
   }
 
   /**
@@ -363,14 +353,19 @@ abstract contract VotesPartialDelegationUpgradeable is
     _useNonce(msg.sender);
   }
 
+  function getActiveDelgateesCount() public view returns (uint256) {
+    VotesPartialDelegationStorage storage $ = _getVotesPartialDelegationStorage();
+    return $._activeDelegatees.length;
+}
+
   /**
    * @dev Delegate `_delegator`'s voting units to delegates specified in `_newDelegations`.
    * Emits events {IVotes-DelegateChanged} and {IVotes-DelegateVotesChanged}.
    */
-  function _delegate(address _delegator, PartialDelegation[] memory _newDelegations) internal virtual {
+function _delegate(address _delegator, PartialDelegation[] memory _newDelegations) internal virtual {
     uint256 _newDelegationsLength = _newDelegations.length;
     if (_newDelegationsLength > MAX_PARTIAL_DELEGATIONS) {
-      revert PartialDelegationLimitExceeded(_newDelegationsLength, MAX_PARTIAL_DELEGATIONS);
+        revert PartialDelegationLimitExceeded(_newDelegationsLength, MAX_PARTIAL_DELEGATIONS);
     }
 
     VotesPartialDelegationStorage storage $ = _getVotesPartialDelegationStorage();
@@ -381,11 +376,28 @@ abstract contract VotesPartialDelegationUpgradeable is
     DelegationAdjustment[] memory _old = new DelegationAdjustment[](_oldDelegateLength);
     uint256 _delegatorVotes = _getVotingUnits(_delegator);
     if (_oldDelegateLength > 0) {
-      _old = _calculateWeightDistribution(_oldDelegations, _delegatorVotes);
+        _old = _calculateWeightDistribution(_oldDelegations, _delegatorVotes);
     }
 
     // Calculate adjustments for new delegatee set.
     DelegationAdjustment[] memory _new = _calculateWeightDistribution(_newDelegations, _delegatorVotes);
+
+    // Calculate changes in voteable supply
+    uint256 oldVoteableAmount = 0;
+    uint256 newVoteableAmount = 0;
+
+    for (uint256 i = 0; i < _oldDelegateLength; i++) {
+        oldVoteableAmount += _old[i]._amount;
+        _updateActiveDelegatee(_old[i]._delegatee, 0);
+    }
+
+    for (uint256 i = 0; i < _newDelegationsLength; i++) {
+        newVoteableAmount += _new[i]._amount;
+        _updateActiveDelegatee(_new[i]._delegatee, _new[i]._amount);
+    }
+
+    // Update voteable supply checkpoint
+    _updateVoteableSupply(oldVoteableAmount, newVoteableAmount);
 
     // Now we want a collated list of all delegatee changes, combining the old subtractions with the new additions.
     // Ideally we'd like to process this only once.
@@ -396,90 +408,105 @@ abstract contract VotesPartialDelegationUpgradeable is
     address _lastDelegatee;
 
     for (uint256 i; i < _newDelegationsLength; i++) {
-      // check sorting and uniqueness
-      if (i == 0 && _newDelegations[i]._delegatee == address(0)) {
-        // zero delegation is allowed if in 0th position
-      } else if (_newDelegations[i]._delegatee <= _lastDelegatee) {
-        revert DuplicateOrUnsortedDelegatees(_newDelegations[i]._delegatee);
-      }
-
-      // replace existing delegatees in storage
-      if (i < _oldDelegateLength) {
-        $._delegatees[_delegator][i] = _newDelegations[i];
-      }
-      // or add new delegatees
-      else {
-        $._delegatees[_delegator].push(_newDelegations[i]);
-      }
-
-        if (_newDelegations[i]._delegatee != address(0) && !_isDelegateePresent(_newDelegations[i]._delegatee)) {
-            _allDelegatees.push(_newDelegations[i]._delegatee);
+        // check sorting and uniqueness
+        if (i == 0 && _newDelegations[i]._delegatee == address(0)) {
+            // zero delegation is allowed if in 0th position
+        } else if (_newDelegations[i]._delegatee <= _lastDelegatee) {
+            revert DuplicateOrUnsortedDelegatees(_newDelegations[i]._delegatee);
         }
 
-      _lastDelegatee = _newDelegations[i]._delegatee;
+        // replace existing delegatees in storage
+        if (i < _oldDelegateLength) {
+            $._delegatees[_delegator][i] = _newDelegations[i];
+        }
+        // or add new delegatees
+        else {
+            $._delegatees[_delegator].push(_newDelegations[i]);
+        }
+
+        _lastDelegatee = _newDelegations[i]._delegatee;
     }
     // remove any remaining old delegatees
     if (_oldDelegateLength > _newDelegationsLength) {
-      for (uint256 i = _newDelegationsLength; i < _oldDelegateLength; i++) {
-        $._delegatees[_delegator].pop();
-      }
+        for (uint256 i = _newDelegationsLength; i < _oldDelegateLength; i++) {
+            $._delegatees[_delegator].pop();
+        }
     }
     emit DelegateChanged(_delegator, _oldDelegations, _newDelegations);
-  }
+}
 
   /**
    * @dev Transfers, mints, or burns voting units. To register a mint, `from` should be zero. To register a burn, `to`
-   * should be zero. Total supply of voting units will be adjusted with mints and burns.
+   * should be zero. Total supply of voting units will be adjusted with mints and burns. Voteable supply will also stay updated.
    */
-  function _transferVotingUnits(address from, address to, uint256 amount) internal virtual {
+function _transferVotingUnits(address from, address to, uint256 amount) internal virtual {
     // skip from==to no-op, as the math would require special handling
     if (from == to) {
-      return;
+        return;
     }
+
+    VotesPartialDelegationStorage storage $ = _getVotesPartialDelegationStorage();
 
     // update total supply checkpoints if mint/burn
-    VotesPartialDelegationStorage storage $ = _getVotesPartialDelegationStorage();
     if (from == address(0)) {
-      _push($._totalCheckpoints, _add, SafeCast.toUint208(amount));
+        _push($._totalCheckpoints, _add, SafeCast.toUint208(amount));
     }
     if (to == address(0)) {
-      _push($._totalCheckpoints, _subtract, SafeCast.toUint208(amount));
+        _push($._totalCheckpoints, _subtract, SafeCast.toUint208(amount));
     }
 
-    // finally, calculate delegatee vote changes and create checkpoints accordingly
+    // calculate delegatee vote changes and create checkpoints accordingly
     uint256 _fromLength = $._delegatees[from].length;
     DelegationAdjustment[] memory _delegationAdjustmentsFrom = new DelegationAdjustment[](_fromLength);
     // We'll need to adjust the delegatee votes for both "from" and "to" delegatee sets.
     if (_fromLength > 0) {
-      uint256 _fromVotes = _getVotingUnits(from);
-      DelegationAdjustment[] memory _from = _calculateWeightDistribution($._delegatees[from], _fromVotes + amount);
-      DelegationAdjustment[] memory _fromNew = _calculateWeightDistribution($._delegatees[from], _fromVotes);
-      for (uint256 i; i < _fromLength; i++) {
-        _delegationAdjustmentsFrom[i] = DelegationAdjustment({
-          _delegatee: $._delegatees[from][i]._delegatee,
-          _amount: _from[i]._amount - _fromNew[i]._amount
-        });
-      }
+        uint256 _fromVotes = _getVotingUnits(from);
+        DelegationAdjustment[] memory _from = _calculateWeightDistribution($._delegatees[from], _fromVotes + amount);
+        DelegationAdjustment[] memory _fromNew = _calculateWeightDistribution($._delegatees[from], _fromVotes);
+        for (uint256 i; i < _fromLength; i++) {
+            _delegationAdjustmentsFrom[i] = DelegationAdjustment({
+                _delegatee: $._delegatees[from][i]._delegatee,
+                _amount: _from[i]._amount - _fromNew[i]._amount
+            });
+        }
     }
 
     uint256 _toLength = $._delegatees[to].length;
     DelegationAdjustment[] memory _delegationAdjustmentsTo = new DelegationAdjustment[](_toLength);
     if (_toLength > 0) {
-      uint256 _toVotes = _getVotingUnits(to);
-      DelegationAdjustment[] memory _to = _calculateWeightDistribution($._delegatees[to], _toVotes - amount);
-      DelegationAdjustment[] memory _toNew = _calculateWeightDistribution($._delegatees[to], _toVotes);
+        uint256 _toVotes = _getVotingUnits(to);
+        DelegationAdjustment[] memory _to = _calculateWeightDistribution($._delegatees[to], _toVotes - amount);
+        DelegationAdjustment[] memory _toNew = _calculateWeightDistribution($._delegatees[to], _toVotes);
 
-      for (uint256 i; i < _toLength; i++) {
-        _delegationAdjustmentsTo[i] = (
-          DelegationAdjustment({
-            _delegatee: $._delegatees[to][i]._delegatee,
-            _amount: _toNew[i]._amount - _to[i]._amount
-          })
-        );
-      }
+        for (uint256 i; i < _toLength; i++) {
+            _delegationAdjustmentsTo[i] = (
+                DelegationAdjustment({
+                    _delegatee: $._delegatees[to][i]._delegatee,
+                    _amount: _toNew[i]._amount - _to[i]._amount
+                })
+            );
+        }
     }
+
+    // Calculate changes in voteable supply
+    uint256 fromVoteableChange = 0;
+    uint256 toVoteableChange = 0;
+
+    for (uint256 i = 0; i < _fromLength; i++) {
+        fromVoteableChange += _delegationAdjustmentsFrom[i]._amount;
+        _updateActiveDelegatee(_delegationAdjustmentsFrom[i]._delegatee, _getVotes(_delegationAdjustmentsFrom[i]._delegatee) - _delegationAdjustmentsFrom[i]._amount);
+    }
+
+    for (uint256 i = 0; i < _toLength; i++) {
+        toVoteableChange += _delegationAdjustmentsTo[i]._amount;
+        _updateActiveDelegatee(_delegationAdjustmentsTo[i]._delegatee, _getVotes(_delegationAdjustmentsTo[i]._delegatee) + _delegationAdjustmentsTo[i]._amount);
+    }
+
+    // Update voteable supply checkpoint
+    _updateVoteableSupply(fromVoteableChange, toVoteableChange);
+
     _aggregateDelegationAdjustmentsAndCreateCheckpoints(_delegationAdjustmentsFrom, _delegationAdjustmentsTo);
-  }
+}
 
   /**
    * @dev Given an old delegation array and a new delegation array, determine which delegations have changed, create new
@@ -622,13 +649,24 @@ abstract contract VotesPartialDelegationUpgradeable is
       keccak256(abi.encode(PARTIAL_DELEGATION_TYPEHASH, partialDelegation._delegatee, partialDelegation._numerator));
   }
 
-  function _isDelegateePresent(address delegatee) private view returns (bool) {
-    for (uint256 i = 0; i < _allDelegatees.length; i++) {
-        if (_allDelegatees[i] == delegatee) {
-            return true;
+  function _updateVoteableSupply(uint256 oldAmount, uint256 newAmount) internal {
+    if (oldAmount != newAmount) {
+        VotesPartialDelegationStorage storage $ = _getVotesPartialDelegationStorage();
+        if (newAmount > oldAmount) {
+            _push($._voteableSupplyCheckpoints, _add, SafeCast.toUint208(newAmount - oldAmount));
+        } else {
+            _push($._voteableSupplyCheckpoints, _subtract, SafeCast.toUint208(oldAmount - newAmount));
         }
     }
-    return false;
+}
+
+function _updateActiveDelegatee(address delegatee, uint256 amount) internal {
+    VotesPartialDelegationStorage storage $ = _getVotesPartialDelegationStorage();
+    if (amount > 0) {
+        $._activeDelegatees[delegatee] = true;
+    } else if ($._activeDelegatees[delegatee]) {
+        delete $._activeDelegatees[delegatee];
+    }
 }
 
   /**

--- a/src/VotesPartialDelegationUpgradeable.sol
+++ b/src/VotesPartialDelegationUpgradeable.sol
@@ -188,7 +188,9 @@ abstract contract VotesPartialDelegationUpgradeable is
  */
 function getVoteableSupply() public view returns (uint256) {
     VotesPartialDelegationStorage storage $ = _getVotesPartialDelegationStorage();
-    return $._voteableSupplyCheckpoints.latest();
+    uint256 voteableSupply = $._voteableSupplyCheckpoints.latest();
+    uint256 totalSupply = _getTotalSupply();
+    return voteableSupply > totalSupply ? totalSupply : voteableSupply;
 }
 
 /**

--- a/src/VotesPartialDelegationUpgradeable.sol
+++ b/src/VotesPartialDelegationUpgradeable.sol
@@ -351,11 +351,6 @@ function getVoteableSupply() public view returns (uint256) {
     _useNonce(msg.sender);
   }
 
-  function getActiveDelgateesCount() public view returns (uint256) {
-    VotesPartialDelegationStorage storage $ = _getVotesPartialDelegationStorage();
-    return $._activeDelegatees.length;
-}
-
   /**
    * @dev Delegate `_delegator`'s voting units to delegates specified in `_newDelegations`.
    * Emits events {IVotes-DelegateChanged} and {IVotes-DelegateVotesChanged}.
@@ -492,12 +487,12 @@ function _transferVotingUnits(address from, address to, uint256 amount) internal
 
     for (uint256 i = 0; i < _fromLength; i++) {
         fromVoteableChange += _delegationAdjustmentsFrom[i]._amount;
-        _updateActiveDelegatee(_delegationAdjustmentsFrom[i]._delegatee, _getVotes(_delegationAdjustmentsFrom[i]._delegatee) - _delegationAdjustmentsFrom[i]._amount);
+        _updateActiveDelegatee(_delegationAdjustmentsFrom[i]._delegatee, getVotes(_delegationAdjustmentsFrom[i]._delegatee) - _delegationAdjustmentsFrom[i]._amount);
     }
 
     for (uint256 i = 0; i < _toLength; i++) {
         toVoteableChange += _delegationAdjustmentsTo[i]._amount;
-        _updateActiveDelegatee(_delegationAdjustmentsTo[i]._delegatee, _getVotes(_delegationAdjustmentsTo[i]._delegatee) + _delegationAdjustmentsTo[i]._amount);
+        _updateActiveDelegatee(_delegationAdjustmentsTo[i]._delegatee, getVotes(_delegationAdjustmentsTo[i]._delegatee) + _delegationAdjustmentsTo[i]._amount);
     }
 
     // Update voteable supply checkpoint

--- a/src/VotesPartialDelegationUpgradeable.sol
+++ b/src/VotesPartialDelegationUpgradeable.sol
@@ -188,9 +188,7 @@ abstract contract VotesPartialDelegationUpgradeable is
  */
 function getVoteableSupply() public view returns (uint256) {
     VotesPartialDelegationStorage storage $ = _getVotesPartialDelegationStorage();
-    uint256 voteableSupply = $._voteableSupplyCheckpoints.latest();
-    uint256 totalSupply = _getTotalSupply();
-    return voteableSupply > totalSupply ? totalSupply : voteableSupply;
+    return $._voteableSupplyCheckpoints.latest();
 }
 
 /**
@@ -660,12 +658,13 @@ function _transferVotingUnits(address from, address to, uint256 amount) internal
     }
 }
 
-function _updateActiveDelegatee(address delegatee, uint256 amount) internal {
+function _updateActiveDelegatee(address delegatee, uint256 newAmount) internal {
     VotesPartialDelegationStorage storage $ = _getVotesPartialDelegationStorage();
-    if (amount > 0) {
-        $._activeDelegatees[delegatee] = true;
-    } else if ($._activeDelegatees[delegatee]) {
-        delete $._activeDelegatees[delegatee];
+    bool isCurrentlyActive = $._activeDelegatees[delegatee];
+    bool shouldBeActive = newAmount > 0;
+    
+    if (isCurrentlyActive != shouldBeActive) {
+        $._activeDelegatees[delegatee] = shouldBeActive;
     }
 }
 

--- a/src/VotesPartialDelegationUpgradeable.sol
+++ b/src/VotesPartialDelegationUpgradeable.sol
@@ -371,10 +371,6 @@ abstract contract VotesPartialDelegationUpgradeable is
     uint256 _delegatorVotes = _getVotingUnits(_delegator);
     if (_oldDelegateLength > 0) {
       _old = _calculateWeightDistribution(_oldDelegations, _delegatorVotes);
-    } else {
-      // if there are no delegatees, we still need to adjust voteable supply
-      _old = new DelegationAdjustment[](1);
-      _old[0] = DelegationAdjustment({_delegatee: address(0), _amount: uint208(_delegatorVotes)});
     }
 
     // Calculate adjustments for new delegatee set.
@@ -452,11 +448,6 @@ abstract contract VotesPartialDelegationUpgradeable is
           _amount: _from[i]._amount - _fromNew[i]._amount
         });
       }
-    } else {
-      // if there are no delegatees, we still need to adjust voteable supply
-      _delegationAdjustmentsFrom = new DelegationAdjustment[](1);
-      _delegationAdjustmentsFrom[0] =
-        DelegationAdjustment({_delegatee: address(0), _amount: SafeCast.toUint208(amount)});
     }
 
     uint256 _toLength = $._delegatees[to].length;
@@ -474,10 +465,6 @@ abstract contract VotesPartialDelegationUpgradeable is
           })
         );
       }
-    } else {
-      // if there are no delegatees, we still need to adjust voteable supply
-      _delegationAdjustmentsTo = new DelegationAdjustment[](1);
-      _delegationAdjustmentsTo[0] = DelegationAdjustment({_delegatee: address(0), _amount: SafeCast.toUint208(amount)});
     }
     _aggregateDelegationAdjustmentsAndCreateCheckpoints(_delegationAdjustmentsFrom, _delegationAdjustmentsTo);
   }
@@ -636,9 +623,9 @@ abstract contract VotesPartialDelegationUpgradeable is
     return
       keccak256(abi.encode(PARTIAL_DELEGATION_TYPEHASH, partialDelegation._delegatee, partialDelegation._numerator));
   }
+
   /**
    * @dev Must return the voting units held by an account.
    */
-
   function _getVotingUnits(address) internal view virtual returns (uint256);
 }

--- a/src/VotesPartialDelegationUpgradeable.sol
+++ b/src/VotesPartialDelegationUpgradeable.sol
@@ -46,8 +46,8 @@ abstract contract VotesPartialDelegationUpgradeable is
     mapping(address account => PartialDelegation[]) _delegatees;
     mapping(address delegatee => Checkpoints.Trace208) _delegateCheckpoints;
     Checkpoints.Trace208 _totalCheckpoints;
-    // Add checkpoint for voteableSupply
-    Checkpoints.Trace208 _voteableSupplyCheckpoints;
+    // Add checkpoint for votableSupply
+    Checkpoints.Trace208 _votableSupplyCheckpoints;
   }
 
   enum Op {
@@ -180,15 +180,15 @@ abstract contract VotesPartialDelegationUpgradeable is
   /**
    * @dev Returns the current total number of tokens that have been delegated for voting.
    *
-   * This value represents the "voteable supply," which is the sum of all tokens that have been delegated to
+   * This value represents the "votable supply," which is the sum of all tokens that have been delegated to
    * representatives.
    * Tokens that have not been delegated are not included in this count.
    *
    * NOTE: This value is the sum of all delegated votes at the current block.
    */
-  function getVoteableSupply() public view returns (uint256) {
+  function getVotableSupply() public view returns (uint256) {
     VotesPartialDelegationStorage storage $ = _getVotesPartialDelegationStorage();
-    return $._voteableSupplyCheckpoints.latest();
+    return $._votableSupplyCheckpoints.latest();
   }
 
   /**
@@ -196,7 +196,7 @@ abstract contract VotesPartialDelegationUpgradeable is
    * If the `clock()` is configured to use block numbers, this will return the value at the end of the corresponding
    * block.
    *
-   * This value represents the "voteable supply" at a given timepoint, which is the sum of all tokens that were
+   * This value represents the "votable supply" at a given timepoint, which is the sum of all tokens that were
    * delegated
    * to representatives at that specific moment.
    *
@@ -206,15 +206,15 @@ abstract contract VotesPartialDelegationUpgradeable is
    *
    * - `timepoint` must be in the past. If operating using block numbers, the block must be already mined.
    *
-   * @param timepoint The block number or timestamp to query the voteable supply at.
+   * @param timepoint The block number or timestamp to query the votable supply at.
    */
-  function getPastVoteableSupply(uint256 timepoint) public view virtual returns (uint256) {
+  function getPastVotableSupply(uint256 timepoint) public view virtual returns (uint256) {
     VotesPartialDelegationStorage storage $ = _getVotesPartialDelegationStorage();
     uint48 currentTimepoint = clock();
     if (timepoint >= currentTimepoint) {
       revert ERC5805FutureLookup(timepoint, currentTimepoint);
     }
-    return $._voteableSupplyCheckpoints.upperLookupRecent(SafeCast.toUint48(timepoint));
+    return $._votableSupplyCheckpoints.upperLookupRecent(SafeCast.toUint48(timepoint));
   }
 
   /**
@@ -415,7 +415,7 @@ abstract contract VotesPartialDelegationUpgradeable is
 
   /**
    * @dev Transfers, mints, or burns voting units. To register a mint, `from` should be zero. To register a burn, `to`
-   * should be zero. Total supply of voting units will be adjusted with mints and burns. Voteable supply will also stay
+   * should be zero. Total supply of voting units will be adjusted with mints and burns. Votable supply will also stay
    * updated.
    */
   function _transferVotingUnits(address from, address to, uint256 amount) internal virtual {
@@ -545,7 +545,7 @@ abstract contract VotesPartialDelegationUpgradeable is
     if (_votableSupplyChange != 0) {
       bool _isPositive = _votableSupplyChange > 0;
       (uint256 oldValue, uint256 newValue) = _push(
-        $._voteableSupplyCheckpoints,
+        $._votableSupplyCheckpoints,
         _isPositive ? _add : _subtract,
         SafeCast.toUint208(uint256(_isPositive ? _votableSupplyChange : -_votableSupplyChange))
       );

--- a/test/ERC20VotesPartialDelegationUpgradeable.t.sol
+++ b/test/ERC20VotesPartialDelegationUpgradeable.t.sol
@@ -68,7 +68,7 @@ contract PartialDelegationTest is DelegationAndEventHelpers {
 
   function assertCorrectVotableSupply(PartialDelegation[] memory _delegations, uint256 _amount) internal {
     uint256 _totalWeight = _calculateWeightDelegated(_delegations, _amount);
-    assertEq(_totalWeight, tokenProxy.getVoteableSupply(), "incorrect votable supply");
+    assertEq(_totalWeight, tokenProxy.getVotableSupply(), "incorrect votable supply");
   }
 
   function assertCorrectPastVotes(PartialDelegation[] memory _delegations, uint256 _amount, uint256 _timepoint)
@@ -700,7 +700,7 @@ contract DelegateLegacy is PartialDelegationTest {
     tokenProxy.delegate(_delegatee);
     assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_delegatee));
     assertEq(tokenProxy.getVotes(_delegatee), _delegatorBalance);
-    assertEq(tokenProxy.getVoteableSupply(), _delegatorBalance);
+    assertEq(tokenProxy.getVotableSupply(), _delegatorBalance);
   }
 
   function testFuzz_DelegatesSuccessfullyToZeroAddress(
@@ -719,7 +719,7 @@ contract DelegateLegacy is PartialDelegationTest {
     tokenProxy.delegate(_delegatee);
     assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_delegatee));
     assertEq(tokenProxy.getVotes(_delegatee), 0);
-    assertEq(tokenProxy.getVoteableSupply(), 0);
+    assertEq(tokenProxy.getVotableSupply(), 0);
   }
 
   function testFuzz_RedelegatesSuccessfully(
@@ -746,7 +746,7 @@ contract DelegateLegacy is PartialDelegationTest {
     assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_newDelegatee));
     _expectedVotes = _newDelegatee == address(0) ? 0 : _delegatorBalance;
     assertEq(tokenProxy.getVotes(_newDelegatee), _expectedVotes);
-    assertEq(tokenProxy.getVoteableSupply(), _expectedVotes);
+    assertEq(tokenProxy.getVotableSupply(), _expectedVotes);
   }
 
   function testFuzz_RedelegatesToAPartialDelegationSuccessfully(
@@ -805,7 +805,7 @@ contract DelegateBySig is PartialDelegationTest {
     tokenProxy.delegateBySig(_delegatee, _currentNonce, _deadline, _v, _r, _s);
     assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_delegatee));
     assertEq(tokenProxy.getVotes(_delegatee), _delegatorBalance);
-    assertEq(tokenProxy.getVoteableSupply(), _delegatorBalance);
+    assertEq(tokenProxy.getVotableSupply(), _delegatorBalance);
   }
 
   function testFuzz_DelegatesSuccessfullyToZeroAddress(
@@ -832,7 +832,7 @@ contract DelegateBySig is PartialDelegationTest {
     tokenProxy.delegateBySig(_delegatee, _currentNonce, _deadline, _v, _r, _s);
     assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_delegatee));
     assertEq(tokenProxy.getVotes(_delegatee), 0);
-    assertEq(tokenProxy.getVoteableSupply(), 0);
+    assertEq(tokenProxy.getVotableSupply(), 0);
   }
 
   function testFuzz_RevertIf_DelegatesViaERC712SignatureWithExpiredDeadline(
@@ -1552,8 +1552,8 @@ contract GetVotableSupply is PartialDelegationTest {
     tokenProxy.mint(_amount);
     vm.stopPrank();
 
-    uint256 voteableSupply = tokenProxy.getVoteableSupply();
-    assertEq(voteableSupply, 0, "Initial voteable supply should be 0");
+    uint256 votableSupply = tokenProxy.getVotableSupply();
+    assertEq(votableSupply, 0, "Initial votable supply should be 0");
 
     // First delegation
     PartialDelegation[] memory delegations = _createValidPartialDelegation(0, uint256(keccak256(abi.encode(_actor))));
@@ -1561,20 +1561,20 @@ contract GetVotableSupply is PartialDelegationTest {
     tokenProxy.delegate(delegations);
     vm.stopPrank();
 
-    voteableSupply = tokenProxy.getVoteableSupply();
+    votableSupply = tokenProxy.getVotableSupply();
     uint256 _expectedSupply = _calculateWeightDelegated(delegations, _amount);
-    assertEq(voteableSupply, _expectedSupply, "Voteable supply should increase after delegation");
-    assertLe(voteableSupply, tokenProxy.totalSupply(), "Voteable supply should not exceed total supply");
+    assertEq(votableSupply, _expectedSupply, "Votable supply should increase after delegation");
+    assertLe(votableSupply, tokenProxy.totalSupply(), "Votable supply should not exceed total supply");
 
     // Move blocks ahead and second mint
     vm.startPrank(_actor);
     tokenProxy.mint(_secondMint);
     vm.stopPrank();
 
-    uint256 newVoteableSupply = tokenProxy.getVoteableSupply();
+    uint256 newVotableSupply = tokenProxy.getVotableSupply();
     uint256 _newExpectedSupply = _calculateWeightDelegated(delegations, _amount + _secondMint);
-    assertEq(newVoteableSupply, _newExpectedSupply, "Voteable supply should adjust after second mint");
-    assertLe(newVoteableSupply, tokenProxy.totalSupply(), "Voteable supply should not exceed new total supply");
+    assertEq(newVotableSupply, _newExpectedSupply, "Votable supply should adjust after second mint");
+    assertLe(newVotableSupply, tokenProxy.totalSupply(), "Votable supply should not exceed new total supply");
   }
 }
 
@@ -1603,7 +1603,7 @@ contract GetPastVotableSupply is PartialDelegationTest {
     tokenProxy.delegate(delegations);
     vm.stopPrank();
 
-    uint256 voteableSupply = tokenProxy.getVoteableSupply();
+    uint256 votableSupply = tokenProxy.getVotableSupply();
 
     // Move blocks ahead and second mint
     vm.roll(_blockNo + _blocksAhead);
@@ -1612,9 +1612,9 @@ contract GetPastVotableSupply is PartialDelegationTest {
     vm.stopPrank();
 
     assertEq(
-      voteableSupply,
-      tokenProxy.getPastVoteableSupply(_blockNo),
-      "Past voteable supply should equal the value retrieved earlier"
+      votableSupply,
+      tokenProxy.getPastVotableSupply(_blockNo),
+      "Past votable supply should equal the value retrieved earlier"
     );
   }
 }

--- a/test/ERC20VotesPartialDelegationUpgradeable.t.sol
+++ b/test/ERC20VotesPartialDelegationUpgradeable.t.sol
@@ -9,1711 +9,2619 @@ import {MockERC1271Signer} from "test/helpers/MockERC1271Signer.sol";
 import {PartialDelegation, DelegationAdjustment} from "src/IVotesPartialDelegation.sol";
 
 contract PartialDelegationTest is DelegationAndEventHelpers {
-  /// @notice An invalid signature is provided.
-  error InvalidSignature();
-  /// @dev The nonce used for an `account` is not the expected current nonce.
-  error InvalidAccountNonce(address account, uint256 currentNonce);
-  /// @dev The signature used has expired.
-  error VotesExpiredSignature(uint256 expiry);
-  /// @notice Emitted when the number of delegatees exceeds the limit.
-  error PartialDelegationLimitExceeded(uint256 length, uint256 max);
-  /// @notice Emitted when the provided delegatee list is not sorted or contains duplicates.
-  error DuplicateOrUnsortedDelegatees(address delegatee);
-  /// @notice Emitted when the provided numerator is zero.
-  error InvalidNumeratorZero();
-  /// @notice Emitted when the sum of the numerators exceeds the denominator.
-  error NumeratorSumExceedsDenominator(uint256 numerator, uint96 denominator);
+    /// @notice An invalid signature is provided.
+    error InvalidSignature();
+    /// @dev The nonce used for an `account` is not the expected current nonce.
+    error InvalidAccountNonce(address account, uint256 currentNonce);
+    /// @dev The signature used has expired.
+    error VotesExpiredSignature(uint256 expiry);
+    /// @notice Emitted when the number of delegatees exceeds the limit.
+    error PartialDelegationLimitExceeded(uint256 length, uint256 max);
+    /// @notice Emitted when the provided delegatee list is not sorted or contains duplicates.
+    error DuplicateOrUnsortedDelegatees(address delegatee);
+    /// @notice Emitted when the provided numerator is zero.
+    error InvalidNumeratorZero();
+    /// @notice Emitted when the sum of the numerators exceeds the denominator.
+    error NumeratorSumExceedsDenominator(uint256 numerator, uint96 denominator);
 
-  FakeERC20VotesPartialDelegationUpgradeable public tokenImpl;
-  FakeERC20VotesPartialDelegationUpgradeable public tokenProxy;
-  bytes32 DOMAIN_SEPARATOR;
+    FakeERC20VotesPartialDelegationUpgradeable public tokenImpl;
+    FakeERC20VotesPartialDelegationUpgradeable public tokenProxy;
+    bytes32 DOMAIN_SEPARATOR;
 
-  function setUp() public virtual {
-    tokenImpl = new FakeERC20VotesPartialDelegationUpgradeable();
-    tokenProxy = FakeERC20VotesPartialDelegationUpgradeable(address(new ERC1967Proxy(address(tokenImpl), "")));
-    tokenProxy.initialize();
-    DelegationAndEventHelpers.initialize(address(tokenProxy));
-    // TODO: try to build this with contract state rather than fixed values
-    DOMAIN_SEPARATOR = keccak256(
-      abi.encode(
-        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
-        keccak256("Fake Token"),
-        keccak256("1"),
-        block.chainid,
-        address(tokenProxy)
-      )
-    );
-  }
-
-  function assertEq(PartialDelegation[] memory a, PartialDelegation[] memory b) public {
-    assertEq(a.length, b.length, "length mismatch");
-    for (uint256 i = 0; i < a.length; i++) {
-      assertEq(a[i]._delegatee, b[i]._delegatee, "delegatee mismatch");
-      assertEq(a[i]._numerator, b[i]._numerator, "numerator mismatch");
+    function setUp() public virtual {
+        tokenImpl = new FakeERC20VotesPartialDelegationUpgradeable();
+        tokenProxy = FakeERC20VotesPartialDelegationUpgradeable(
+            address(new ERC1967Proxy(address(tokenImpl), ""))
+        );
+        tokenProxy.initialize();
+        DelegationAndEventHelpers.initialize(address(tokenProxy));
+        // TODO: try to build this with contract state rather than fixed values
+        DOMAIN_SEPARATOR = keccak256(
+            abi.encode(
+                keccak256(
+                    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                ),
+                keccak256("Fake Token"),
+                keccak256("1"),
+                block.chainid,
+                address(tokenProxy)
+            )
+        );
     }
-  }
 
-  function assertCorrectVotes(PartialDelegation[] memory _delegations, uint256 _amount) internal {
-    DelegationAdjustment[] memory _votes = tokenProxy.exposed_calculateWeightDistribution(_delegations, _amount);
-    uint256 _totalWeight = 0;
-    for (uint256 i = 0; i < _delegations.length; i++) {
-      uint256 _expectedVoteWeight = _delegations[i]._delegatee == address(0) ? 0 : _votes[i]._amount;
-      assertEq(
-        tokenProxy.getVotes(_delegations[i]._delegatee), _expectedVoteWeight, "incorrect vote weight for delegate"
-      );
-      _totalWeight += _votes[i]._amount;
-    }
-    assertLe(_totalWeight, _amount, "incorrect total weight");
-  }
-
-  function assertCorrectPastVotes(PartialDelegation[] memory _delegations, uint256 _amount, uint256 _timepoint)
-    internal
-  {
-    DelegationAdjustment[] memory _votes = tokenProxy.exposed_calculateWeightDistribution(_delegations, _amount);
-    uint256 _totalWeight = 0;
-    for (uint256 i = 0; i < _delegations.length; i++) {
-      uint256 _expectedVoteWeight = _votes[i]._amount;
-      assertEq(
-        tokenProxy.getPastVotes(_delegations[i]._delegatee, _timepoint),
-        _expectedVoteWeight,
-        "incorrect past vote weight for delegate"
-      );
-      _totalWeight += _votes[i]._amount;
-    }
-    assertLe(_totalWeight, _amount, "incorrect total weight");
-  }
-
-  function _mint(address _to, uint256 _amount) internal {
-    vm.prank(_to);
-    tokenProxy.mint(_amount);
-  }
-
-  function _createSingleFullDelegation(address _delegatee) internal view returns (PartialDelegation[] memory) {
-    PartialDelegation[] memory delegations = new PartialDelegation[](1);
-    delegations[0] = PartialDelegation(_delegatee, tokenProxy.DENOMINATOR());
-    return delegations;
-  }
-
-  function _expectEmitDelegateVotesChangedEvents(
-    uint256 _amount,
-    uint256 _toExistingBalance,
-    PartialDelegation[] memory _fromPartialDelegations,
-    PartialDelegation[] memory _toPartialDelegations
-  ) internal {
-    DelegationAdjustment[] memory _fromVotes =
-      tokenProxy.exposed_calculateWeightDistribution(_fromPartialDelegations, _amount);
-    DelegationAdjustment[] memory _toInitialVotes =
-      tokenProxy.exposed_calculateWeightDistribution(_toPartialDelegations, _toExistingBalance);
-    DelegationAdjustment[] memory _toVotes =
-      tokenProxy.exposed_calculateWeightDistribution(_toPartialDelegations, _amount + _toExistingBalance);
-
-    uint256 i;
-    uint256 j;
-    while (i < _fromPartialDelegations.length || j < _toPartialDelegations.length) {
-      // If both delegations have the same delegatee
-      if (
-        i < _fromPartialDelegations.length && j < _toPartialDelegations.length
-          && _fromPartialDelegations[i]._delegatee == _toPartialDelegations[j]._delegatee
-      ) {
-        // if the numerator is different
-        if (_fromPartialDelegations[i]._numerator != _toPartialDelegations[j]._numerator) {
-          if (_toVotes[j]._amount != 0 || _fromVotes[j]._amount != 0) {
-            vm.expectEmit();
-            emit DelegateVotesChanged(_fromPartialDelegations[i]._delegatee, _fromVotes[j]._amount, _toVotes[j]._amount);
-          }
+    function assertEq(
+        PartialDelegation[] memory a,
+        PartialDelegation[] memory b
+    ) public {
+        assertEq(a.length, b.length, "length mismatch");
+        for (uint256 i = 0; i < a.length; i++) {
+            assertEq(a[i]._delegatee, b[i]._delegatee, "delegatee mismatch");
+            assertEq(a[i]._numerator, b[i]._numerator, "numerator mismatch");
         }
-        i++;
-        j++;
-        // Old delegatee comes before the new delegatee OR new delegatees have been exhausted
-      } else if (
-        j == _toPartialDelegations.length
-          || (
-            i != _fromPartialDelegations.length
-              && _fromPartialDelegations[i]._delegatee < _toPartialDelegations[j]._delegatee
-          )
-      ) {
-        if (_fromVotes[i]._amount != 0) {
-          vm.expectEmit();
-          emit DelegateVotesChanged(_fromPartialDelegations[i]._delegatee, _fromVotes[i]._amount, 0);
-        }
-        i++;
-        // If new delegatee comes before the old delegatee OR old delegatees have been exhausted
-      } else {
-        // If the new delegatee vote weight is not the same as its previous vote weight
-        if (_toVotes[j]._amount != 0 && _toVotes[j]._amount != _toInitialVotes[j]._amount) {
-          vm.expectEmit();
-          emit DelegateVotesChanged(
-            _toPartialDelegations[j]._delegatee, _toInitialVotes[j]._amount, _toVotes[j]._amount
-          );
-        }
-        j++;
-      }
     }
-  }
 
-  function _sign(uint256 _privateKey, bytes32 _messageHash) internal pure returns (bytes memory) {
-    (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_privateKey, _messageHash);
-    return abi.encodePacked(_r, _s, _v);
-  }
+    function assertCorrectVotes(
+        PartialDelegation[] memory _delegations,
+        uint256 _amount
+    ) internal {
+        DelegationAdjustment[] memory _votes = tokenProxy
+            .exposed_calculateWeightDistribution(_delegations, _amount);
+        uint256 _totalWeight = 0;
+        for (uint256 i = 0; i < _delegations.length; i++) {
+            uint256 _expectedVoteWeight = _delegations[i]._delegatee ==
+                address(0)
+                ? 0
+                : _votes[i]._amount;
+            assertEq(
+                tokenProxy.getVotes(_delegations[i]._delegatee),
+                _expectedVoteWeight,
+                "incorrect vote weight for delegate"
+            );
+            _totalWeight += _votes[i]._amount;
+        }
+        assertLe(_totalWeight, _amount, "incorrect total weight");
+    }
 
-  function _hash(PartialDelegation memory partialDelegation) internal view returns (bytes32) {
-    return keccak256(
-      abi.encode(tokenProxy.PARTIAL_DELEGATION_TYPEHASH(), partialDelegation._delegatee, partialDelegation._numerator)
-    );
-  }
+    function assertCorrectPastVotes(
+        PartialDelegation[] memory _delegations,
+        uint256 _amount,
+        uint256 _timepoint
+    ) internal {
+        DelegationAdjustment[] memory _votes = tokenProxy
+            .exposed_calculateWeightDistribution(_delegations, _amount);
+        uint256 _totalWeight = 0;
+        for (uint256 i = 0; i < _delegations.length; i++) {
+            uint256 _expectedVoteWeight = _votes[i]._amount;
+            assertEq(
+                tokenProxy.getPastVotes(_delegations[i]._delegatee, _timepoint),
+                _expectedVoteWeight,
+                "incorrect past vote weight for delegate"
+            );
+            _totalWeight += _votes[i]._amount;
+        }
+        assertLe(_totalWeight, _amount, "incorrect total weight");
+    }
+
+    function _mint(address _to, uint256 _amount) internal {
+        vm.prank(_to);
+        tokenProxy.mint(_amount);
+    }
+
+    function _createSingleFullDelegation(
+        address _delegatee
+    ) internal view returns (PartialDelegation[] memory) {
+        PartialDelegation[] memory delegations = new PartialDelegation[](1);
+        delegations[0] = PartialDelegation(
+            _delegatee,
+            tokenProxy.DENOMINATOR()
+        );
+        return delegations;
+    }
+
+    function _expectEmitDelegateVotesChangedEvents(
+        uint256 _amount,
+        uint256 _toExistingBalance,
+        PartialDelegation[] memory _fromPartialDelegations,
+        PartialDelegation[] memory _toPartialDelegations
+    ) internal {
+        DelegationAdjustment[] memory _fromVotes = tokenProxy
+            .exposed_calculateWeightDistribution(
+                _fromPartialDelegations,
+                _amount
+            );
+        DelegationAdjustment[] memory _toInitialVotes = tokenProxy
+            .exposed_calculateWeightDistribution(
+                _toPartialDelegations,
+                _toExistingBalance
+            );
+        DelegationAdjustment[] memory _toVotes = tokenProxy
+            .exposed_calculateWeightDistribution(
+                _toPartialDelegations,
+                _amount + _toExistingBalance
+            );
+
+        uint256 i;
+        uint256 j;
+        while (
+            i < _fromPartialDelegations.length ||
+            j < _toPartialDelegations.length
+        ) {
+            // If both delegations have the same delegatee
+            if (
+                i < _fromPartialDelegations.length &&
+                j < _toPartialDelegations.length &&
+                _fromPartialDelegations[i]._delegatee ==
+                _toPartialDelegations[j]._delegatee
+            ) {
+                // if the numerator is different
+                if (
+                    _fromPartialDelegations[i]._numerator !=
+                    _toPartialDelegations[j]._numerator
+                ) {
+                    if (
+                        _toVotes[j]._amount != 0 || _fromVotes[j]._amount != 0
+                    ) {
+                        vm.expectEmit();
+                        emit DelegateVotesChanged(
+                            _fromPartialDelegations[i]._delegatee,
+                            _fromVotes[j]._amount,
+                            _toVotes[j]._amount
+                        );
+                    }
+                }
+                i++;
+                j++;
+                // Old delegatee comes before the new delegatee OR new delegatees have been exhausted
+            } else if (
+                j == _toPartialDelegations.length ||
+                (i != _fromPartialDelegations.length &&
+                    _fromPartialDelegations[i]._delegatee <
+                    _toPartialDelegations[j]._delegatee)
+            ) {
+                if (_fromVotes[i]._amount != 0) {
+                    vm.expectEmit();
+                    emit DelegateVotesChanged(
+                        _fromPartialDelegations[i]._delegatee,
+                        _fromVotes[i]._amount,
+                        0
+                    );
+                }
+                i++;
+                // If new delegatee comes before the old delegatee OR old delegatees have been exhausted
+            } else {
+                // If the new delegatee vote weight is not the same as its previous vote weight
+                if (
+                    _toVotes[j]._amount != 0 &&
+                    _toVotes[j]._amount != _toInitialVotes[j]._amount
+                ) {
+                    vm.expectEmit();
+                    emit DelegateVotesChanged(
+                        _toPartialDelegations[j]._delegatee,
+                        _toInitialVotes[j]._amount,
+                        _toVotes[j]._amount
+                    );
+                }
+                j++;
+            }
+        }
+    }
+
+    function _sign(
+        uint256 _privateKey,
+        bytes32 _messageHash
+    ) internal pure returns (bytes memory) {
+        (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_privateKey, _messageHash);
+        return abi.encodePacked(_r, _s, _v);
+    }
+
+    function _hash(
+        PartialDelegation memory partialDelegation
+    ) internal view returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    tokenProxy.PARTIAL_DELEGATION_TYPEHASH(),
+                    partialDelegation._delegatee,
+                    partialDelegation._numerator
+                )
+            );
+    }
 }
 
 contract Delegate is PartialDelegationTest {
-  function testFuzz_DelegatesToAnySingleNonZeroAddress(
-    address _actor,
-    address _delegatee,
-    uint96 _numerator,
-    uint256 _amount
-  ) public {
-    vm.assume(_actor != address(0));
-    vm.assume(_delegatee != address(0));
-    _numerator = uint96(bound(_numerator, 1, tokenProxy.DENOMINATOR()));
-    _amount = bound(_amount, 0, type(uint208).max);
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-    PartialDelegation[] memory delegations = new PartialDelegation[](1);
-    delegations[0] = PartialDelegation(_delegatee, _numerator);
-    tokenProxy.delegate(delegations);
-    vm.stopPrank();
-    assertEq(tokenProxy.delegates(_actor), delegations);
-    DelegationAdjustment[] memory adjustments = tokenProxy.exposed_calculateWeightDistribution(delegations, _amount);
-    assertEq(tokenProxy.getVotes(_delegatee), adjustments[0]._amount);
-  }
-
-  function testFuzz_DelegatesOnlyToZeroAddress(address _actor, uint96 _numerator, uint256 _amount) public {
-    vm.assume(_actor != address(0));
-    address _delegatee = address(0);
-    _numerator = uint96(bound(_numerator, 1, tokenProxy.DENOMINATOR()));
-    _amount = bound(_amount, 0, type(uint208).max);
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-    PartialDelegation[] memory delegations = new PartialDelegation[](1);
-    delegations[0] = PartialDelegation(_delegatee, _numerator);
-    tokenProxy.delegate(delegations);
-    vm.stopPrank();
-    assertEq(tokenProxy.delegates(_actor), delegations);
-    assertEq(tokenProxy.getVotes(_delegatee), 0);
-  }
-
-  function testFuzz_DelegatesToTwoAddresses(
-    address _actor,
-    address _delegatee1,
-    address _delegatee2,
-    uint256 _amount,
-    uint96 _numerator1,
-    uint96 _numerator2
-  ) public {
-    vm.assume(_actor != address(0));
-    vm.assume(_delegatee1 != address(0));
-    vm.assume(_delegatee2 != address(0));
-    vm.assume(_delegatee1 < _delegatee2);
-    _amount = bound(_amount, 0, type(uint208).max);
-    _numerator1 = uint96(bound(_numerator1, 1, tokenProxy.DENOMINATOR() - 1));
-    _numerator2 = uint96(bound(_numerator2, 1, tokenProxy.DENOMINATOR() - _numerator1));
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-    PartialDelegation[] memory delegations = new PartialDelegation[](2);
-    delegations[0] = PartialDelegation(_delegatee1, _numerator1);
-    delegations[1] = PartialDelegation(_delegatee2, _numerator2);
-    tokenProxy.delegate(delegations);
-    vm.stopPrank();
-    assertEq(tokenProxy.delegates(_actor), delegations);
-    assertCorrectVotes(delegations, _amount);
-  }
-
-  function testFuzz_DelegatesToNAddresses(address _actor, uint256 _amount, uint256 _n, uint256 _seed) public {
-    vm.assume(_actor != address(0));
-    _amount = bound(_amount, 0, type(uint208).max);
-    _n = bound(_n, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-    PartialDelegation[] memory delegations = _createValidPartialDelegation(_n, _seed);
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-    tokenProxy.delegate(delegations);
-    vm.stopPrank();
-    assertEq(tokenProxy.delegates(_actor), delegations);
-    assertCorrectVotes(delegations, _amount);
-  }
-
-  function testFuzz_DelegatesToNAddressesAndThenDelegatesToOtherAddresses(
-    address _actor,
-    uint256 _amount,
-    uint256 _n,
-    uint256 _seed
-  ) public {
-    vm.assume(_actor != address(0));
-    _amount = bound(_amount, 0, type(uint208).max);
-    _n = bound(_n, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-    PartialDelegation[] memory delegations = _createValidPartialDelegation(_n, _seed);
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-    tokenProxy.delegate(delegations);
-    vm.stopPrank();
-    assertEq(tokenProxy.delegates(_actor), delegations);
-    PartialDelegation[] memory newDelegations = _createValidPartialDelegation( /* setting n to 0 here means seed will
-      generate random n */ 0, uint256(keccak256(abi.encode(_seed))));
-    vm.startPrank(_actor);
-    tokenProxy.delegate(newDelegations);
-    vm.stopPrank();
-    assertEq(tokenProxy.delegates(_actor), newDelegations);
-    assertCorrectVotes(newDelegations, _amount);
-    // initial delegates should have 0 vote power (assuming set union is empty)
-    for (uint256 i = 0; i < delegations.length; i++) {
-      assertEq(tokenProxy.getVotes(delegations[i]._delegatee), 0, "initial delegate has vote power");
-    }
-  }
-
-  function testFuzz_EmitsDelegateChangedEvents(address _actor, uint256 _amount, uint256 _n, uint256 _seed) public {
-    vm.assume(_actor != address(0));
-    _amount = bound(_amount, 0, type(uint208).max);
-    _n = bound(_n, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-    PartialDelegation[] memory delegations = _createValidPartialDelegation(_n, _seed);
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-
-    vm.expectEmit();
-    emit DelegateChanged(_actor, new PartialDelegation[](0), delegations);
-    tokenProxy.delegate(delegations);
-    vm.stopPrank();
-  }
-
-  function testFuzz_EmitsDelegateVotesChanged(address _actor, uint256 _amount, uint256 _n, uint256 _seed) public {
-    vm.assume(_actor != address(0));
-    _amount = bound(_amount, 0, type(uint208).max);
-    _n = bound(_n, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-    PartialDelegation[] memory delegations = _createValidPartialDelegation(_n, _seed);
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-
-    _expectEmitDelegateVotesChangedEvents(_amount, new PartialDelegation[](0), delegations);
-    tokenProxy.delegate(delegations);
-    vm.stopPrank();
-  }
-
-  function testFuzz_EmitsDelegateChangedEventsWhenDelegateesAreRemoved(
-    address _actor,
-    uint256 _amount,
-    uint256 _oldN,
-    uint256 _numOfDelegateesToRemove,
-    uint256 _seed
-  ) public {
-    vm.assume(_actor != address(0));
-    _amount = bound(_amount, 0, type(uint208).max);
-    _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-    _numOfDelegateesToRemove = bound(_numOfDelegateesToRemove, 0, _oldN - 1);
-    PartialDelegation[] memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-    tokenProxy.delegate(oldDelegations);
-
-    PartialDelegation[] memory newDelegations = new PartialDelegation[](_oldN - _numOfDelegateesToRemove);
-    for (uint256 i; i < newDelegations.length; i++) {
-      newDelegations[i] = oldDelegations[i];
+    function testFuzz_DelegatesToAnySingleNonZeroAddress(
+        address _actor,
+        address _delegatee,
+        uint96 _numerator,
+        uint256 _amount
+    ) public {
+        vm.assume(_actor != address(0));
+        vm.assume(_delegatee != address(0));
+        _numerator = uint96(bound(_numerator, 1, tokenProxy.DENOMINATOR()));
+        _amount = bound(_amount, 0, type(uint208).max);
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+        PartialDelegation[] memory delegations = new PartialDelegation[](1);
+        delegations[0] = PartialDelegation(_delegatee, _numerator);
+        tokenProxy.delegate(delegations);
+        vm.stopPrank();
+        assertEq(tokenProxy.delegates(_actor), delegations);
+        DelegationAdjustment[] memory adjustments = tokenProxy
+            .exposed_calculateWeightDistribution(delegations, _amount);
+        assertEq(tokenProxy.getVotes(_delegatee), adjustments[0]._amount);
     }
 
-    vm.expectEmit();
-    emit DelegateChanged(_actor, oldDelegations, newDelegations);
-    tokenProxy.delegate(newDelegations);
-    vm.stopPrank();
-  }
-
-  function testFuzz_EmitsDelegateChangedEventsWhenAllNumeratorsForCurrentDelegateesAreChanged(
-    address _actor,
-    uint256 _amount,
-    uint256 _oldN,
-    uint256 _newN,
-    uint256 _seed
-  ) public {
-    vm.assume(_actor != address(0));
-    _amount = bound(_amount, 0, type(uint208).max);
-    _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-    _newN = bound(_newN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-    PartialDelegation[] memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-    tokenProxy.delegate(oldDelegations);
-    PartialDelegation[] memory newDelegations = oldDelegations;
-
-    // Arthimatic overflow/underflow error without this bounding.
-    _seed = bound(
-      _seed,
-      1,
-      /* private key can't be bigger than secp256k1 curve order */
-      115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 - 1
-    );
-    uint96 _totalNumerator;
-    for (uint256 i = 0; i < _oldN; i++) {
-      uint96 _numerator = uint96(
-        bound(
-          uint256(keccak256(abi.encode(_seed + i))) % tokenProxy.DENOMINATOR(), // initial value of the numerator
-          1,
-          tokenProxy.DENOMINATOR() - _totalNumerator - (_oldN - i) // ensure that there is enough numerator left for the
-            // remaining delegations
-        )
-      );
-      newDelegations[i]._numerator = _numerator;
-      _totalNumerator += _numerator;
+    function testFuzz_DelegatesOnlyToZeroAddress(
+        address _actor,
+        uint96 _numerator,
+        uint256 _amount
+    ) public {
+        vm.assume(_actor != address(0));
+        address _delegatee = address(0);
+        _numerator = uint96(bound(_numerator, 1, tokenProxy.DENOMINATOR()));
+        _amount = bound(_amount, 0, type(uint208).max);
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+        PartialDelegation[] memory delegations = new PartialDelegation[](1);
+        delegations[0] = PartialDelegation(_delegatee, _numerator);
+        tokenProxy.delegate(delegations);
+        vm.stopPrank();
+        assertEq(tokenProxy.delegates(_actor), delegations);
+        assertEq(tokenProxy.getVotes(_delegatee), 0);
     }
 
-    vm.expectEmit();
-    emit DelegateChanged(_actor, oldDelegations, newDelegations);
-    tokenProxy.delegate(newDelegations);
-    vm.stopPrank();
-  }
-
-  function testFuzz_EmitsDelegateChangedEventsWhenAllDelegatesAreReplaced(
-    address _actor,
-    uint256 _amount,
-    uint256 _oldN,
-    uint256 _newN,
-    uint256 _seed
-  ) public {
-    vm.assume(_actor != address(0));
-    _amount = bound(_amount, 0, type(uint208).max);
-    _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-    _newN = bound(_newN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-    PartialDelegation[] memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-    tokenProxy.delegate(oldDelegations);
-
-    PartialDelegation[] memory newDelegations =
-      _createValidPartialDelegation(_newN, uint256(keccak256(abi.encode(_seed))));
-    vm.expectEmit();
-    emit DelegateChanged(_actor, oldDelegations, newDelegations);
-    tokenProxy.delegate(newDelegations);
-    vm.stopPrank();
-  }
-
-  function testFuzz_EmitsDelegateVotesChangedEventsWhenAllNumeratorsForCurrentDelegateesAreChanged(
-    address _actor,
-    uint256 _amount,
-    uint256 _oldN,
-    uint256 _newN,
-    uint256 _seed
-  ) public {
-    vm.assume(_actor != address(0));
-    _amount = bound(_amount, 0, type(uint208).max);
-    _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-    _newN = bound(_newN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-    PartialDelegation[] memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-    tokenProxy.delegate(oldDelegations);
-    PartialDelegation[] memory newDelegations = oldDelegations;
-
-    _seed = bound(
-      _seed,
-      1,
-      /* private key can't be bigger than secp256k1 curve order */
-      115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 - 1
-    );
-    uint96 _totalNumerator;
-    for (uint256 i = 0; i < _oldN; i++) {
-      uint96 _numerator = uint96(
-        bound(
-          uint256(keccak256(abi.encode(_seed + i))) % tokenProxy.DENOMINATOR(), // initial value of the numerator
-          1,
-          tokenProxy.DENOMINATOR() - _totalNumerator - (_oldN - i) // ensure that there is enough numerator left for the
-            // remaining delegations
-        )
-      );
-      newDelegations[i]._numerator = _numerator;
-      _totalNumerator += _numerator;
+    function testFuzz_DelegatesToTwoAddresses(
+        address _actor,
+        address _delegatee1,
+        address _delegatee2,
+        uint256 _amount,
+        uint96 _numerator1,
+        uint96 _numerator2
+    ) public {
+        vm.assume(_actor != address(0));
+        vm.assume(_delegatee1 != address(0));
+        vm.assume(_delegatee2 != address(0));
+        vm.assume(_delegatee1 < _delegatee2);
+        _amount = bound(_amount, 0, type(uint208).max);
+        _numerator1 = uint96(
+            bound(_numerator1, 1, tokenProxy.DENOMINATOR() - 1)
+        );
+        _numerator2 = uint96(
+            bound(_numerator2, 1, tokenProxy.DENOMINATOR() - _numerator1)
+        );
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+        PartialDelegation[] memory delegations = new PartialDelegation[](2);
+        delegations[0] = PartialDelegation(_delegatee1, _numerator1);
+        delegations[1] = PartialDelegation(_delegatee2, _numerator2);
+        tokenProxy.delegate(delegations);
+        vm.stopPrank();
+        assertEq(tokenProxy.delegates(_actor), delegations);
+        assertCorrectVotes(delegations, _amount);
     }
 
-    _expectEmitDelegateVotesChangedEvents(_amount, oldDelegations, newDelegations);
-    tokenProxy.delegate(newDelegations);
-    vm.stopPrank();
-  }
-
-  function testFuzz_EmitsDelegateVotesChangedEventsWhenDelegateesAreRemoved(
-    address _actor,
-    uint256 _amount,
-    uint256 _oldN,
-    uint256 _numOfDelegateesToRemove,
-    uint256 _seed
-  ) public {
-    vm.assume(_actor != address(0));
-    _amount = bound(_amount, 0, type(uint208).max);
-    _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-    _numOfDelegateesToRemove = bound(_numOfDelegateesToRemove, 0, _oldN - 1);
-    PartialDelegation[] memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-    tokenProxy.delegate(oldDelegations);
-
-    PartialDelegation[] memory newDelegations = new PartialDelegation[](_oldN - _numOfDelegateesToRemove);
-    for (uint256 i; i < newDelegations.length; i++) {
-      newDelegations[i] = oldDelegations[i];
+    function testFuzz_DelegatesToNAddresses(
+        address _actor,
+        uint256 _amount,
+        uint256 _n,
+        uint256 _seed
+    ) public {
+        vm.assume(_actor != address(0));
+        _amount = bound(_amount, 0, type(uint208).max);
+        _n = bound(_n, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+        PartialDelegation[] memory delegations = _createValidPartialDelegation(
+            _n,
+            _seed
+        );
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+        tokenProxy.delegate(delegations);
+        vm.stopPrank();
+        assertEq(tokenProxy.delegates(_actor), delegations);
+        assertCorrectVotes(delegations, _amount);
     }
 
-    _expectEmitDelegateVotesChangedEvents(_amount, oldDelegations, newDelegations);
-    tokenProxy.delegate(newDelegations);
-    vm.stopPrank();
-  }
-
-  function testFuzz_EmitsDelegateVotesChangedEventsWhenAllDelegatesAreReplaced(
-    address _actor,
-    uint256 _amount,
-    uint256 _oldN,
-    uint256 _newN,
-    uint256 _seed
-  ) public {
-    vm.assume(_actor != address(0));
-    _amount = bound(_amount, 0, type(uint208).max);
-    _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-    _newN = bound(_newN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-
-    PartialDelegation[] memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-    tokenProxy.delegate(oldDelegations);
-
-    PartialDelegation[] memory newDelegations =
-      _createValidPartialDelegation(_newN, uint256(keccak256(abi.encode(_seed))));
-    _expectEmitDelegateVotesChangedEvents(_amount, oldDelegations, newDelegations);
-    tokenProxy.delegate(newDelegations);
-    vm.stopPrank();
-  }
-
-  function testFuzz_RevertIf_DelegationArrayIncludesDuplicates(
-    address _actor,
-    address _delegatee,
-    uint256 _amount,
-    uint96 _numerator
-  ) public {
-    vm.assume(_actor != address(0));
-    vm.assume(_delegatee != address(0));
-    _amount = bound(_amount, 0, type(uint208).max);
-    _numerator = uint96(bound(_numerator, 1, tokenProxy.DENOMINATOR() - 1));
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-    PartialDelegation[] memory delegations = new PartialDelegation[](2);
-    delegations[0] = PartialDelegation(_delegatee, _numerator);
-    delegations[1] = PartialDelegation(_delegatee, tokenProxy.DENOMINATOR() - _numerator);
-    vm.expectRevert();
-    tokenProxy.delegate(delegations);
-    vm.stopPrank();
-  }
-
-  function testFuzz_RevertIf_DelegationArrayNumeratorsSumToGreaterThanDenominator(
-    address _actor,
-    address _delegatee1,
-    address _delegatee2,
-    uint256 _amount,
-    uint96 _numerator1,
-    uint96 _numerator2
-  ) public {
-    vm.assume(_actor != address(0));
-    vm.assume(_delegatee1 != address(0));
-    vm.assume(_delegatee2 != address(0));
-    vm.assume(_delegatee1 < _delegatee2);
-    _amount = bound(_amount, 0, type(uint208).max);
-    _numerator1 = uint96(bound(_numerator1, 1, tokenProxy.DENOMINATOR()));
-    _numerator2 = uint96(bound(_numerator2, tokenProxy.DENOMINATOR() - _numerator1 + 1, type(uint96).max - _numerator1));
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-    PartialDelegation[] memory delegations = new PartialDelegation[](2);
-    delegations[0] = PartialDelegation(_delegatee1, _numerator1);
-    delegations[1] = PartialDelegation(_delegatee2, _numerator2);
-    vm.expectRevert();
-    tokenProxy.delegate(delegations);
-    vm.stopPrank();
-  }
-
-  function testFuzz_RevertIf_DelegationNumeratorTooLarge(
-    address _actor,
-    address _delegatee,
-    uint256 _amount,
-    uint96 _numerator
-  ) public {
-    vm.assume(_actor != address(0));
-    vm.assume(_delegatee != address(0));
-    _numerator = uint96(bound(_numerator, tokenProxy.DENOMINATOR() + 1, type(uint96).max));
-    _amount = bound(_amount, 0, type(uint208).max);
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-    PartialDelegation[] memory delegations = new PartialDelegation[](1);
-    delegations[0] = PartialDelegation(_delegatee, _numerator);
-    vm.expectRevert();
-    tokenProxy.delegate(delegations);
-    vm.stopPrank();
-  }
-
-  function testFuzz_RevertIf_PartialDelegationLimitExceeded(
-    address _actor,
-    uint256 _amount,
-    uint256 _numOfDelegatees,
-    uint256 _seed
-  ) public {
-    vm.assume(_actor != address(0));
-    _amount = bound(_amount, 0, type(uint208).max);
-    _numOfDelegatees =
-      bound(_numOfDelegatees, tokenProxy.MAX_PARTIAL_DELEGATIONS() + 1, tokenProxy.MAX_PARTIAL_DELEGATIONS() + 500);
-    PartialDelegation[] memory delegations = _createValidPartialDelegation(_numOfDelegatees, _seed);
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-    vm.expectRevert(
-      abi.encodeWithSelector(
-        PartialDelegationLimitExceeded.selector, _numOfDelegatees, tokenProxy.MAX_PARTIAL_DELEGATIONS()
-      )
-    );
-    tokenProxy.delegate(delegations);
-    vm.stopPrank();
-  }
-
-  function testFuzz_RevertIf_DuplicateOrUnsortedDelegatees(
-    address _actor,
-    uint256 _amount,
-    uint256 _numOfDelegatees,
-    address _replacedDelegatee,
-    uint256 _seed
-  ) public {
-    vm.assume(_actor != address(0));
-    _amount = bound(_amount, 0, type(uint208).max);
-    _numOfDelegatees = bound(_numOfDelegatees, 2, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-    PartialDelegation[] memory delegations = _createValidPartialDelegation(_numOfDelegatees, _seed);
-    address lastDelegatee = delegations[delegations.length - 1]._delegatee;
-    vm.assume(_replacedDelegatee <= lastDelegatee);
-    delegations[delegations.length - 1]._delegatee = _replacedDelegatee;
-
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-    vm.expectRevert(abi.encodeWithSelector(DuplicateOrUnsortedDelegatees.selector, _replacedDelegatee));
-    tokenProxy.delegate(delegations);
-    vm.stopPrank();
-  }
-
-  function testFuzz_RevertIf_InvalidNumeratorZero(
-    address _actor,
-    uint256 _amount,
-    uint256 _delegationIndex,
-    uint256 _seed
-  ) public {
-    vm.assume(_actor != address(0));
-    _amount = bound(_amount, 0, type(uint208).max);
-    PartialDelegation[] memory delegations = _createValidPartialDelegation(0, _seed);
-    _delegationIndex = bound(_delegationIndex, 0, delegations.length - 1);
-
-    delegations[_delegationIndex]._numerator = 0;
-
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-    vm.expectRevert(InvalidNumeratorZero.selector);
-    tokenProxy.delegate(delegations);
-    vm.stopPrank();
-  }
-
-  function testFuzz_RevertIf_NumeratorSumExceedsDenominator(
-    address _actor,
-    uint256 _amount,
-    uint256 _delegationIndex,
-    uint256 _seed
-  ) public {
-    vm.assume(_actor != address(0));
-    _amount = bound(_amount, 0, type(uint208).max);
-    PartialDelegation[] memory delegations = _createValidPartialDelegation(0, _seed);
-    _delegationIndex = bound(_delegationIndex, 0, delegations.length - 1);
-
-    delegations[_delegationIndex]._numerator = tokenProxy.DENOMINATOR() + 1;
-    uint256 sumOfNumerators;
-    for (uint256 i; i < delegations.length; i++) {
-      sumOfNumerators += delegations[i]._numerator;
+    function testFuzz_DelegatesToNAddressesAndThenDelegatesToOtherAddresses(
+        address _actor,
+        uint256 _amount,
+        uint256 _n,
+        uint256 _seed
+    ) public {
+        vm.assume(_actor != address(0));
+        _amount = bound(_amount, 0, type(uint208).max);
+        _n = bound(_n, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+        PartialDelegation[] memory delegations = _createValidPartialDelegation(
+            _n,
+            _seed
+        );
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+        tokenProxy.delegate(delegations);
+        vm.stopPrank();
+        assertEq(tokenProxy.delegates(_actor), delegations);
+        PartialDelegation[]
+            memory newDelegations = _createValidPartialDelegation(
+                /* setting n to 0 here means seed will
+      generate random n */ 0,
+                uint256(keccak256(abi.encode(_seed)))
+            );
+        vm.startPrank(_actor);
+        tokenProxy.delegate(newDelegations);
+        vm.stopPrank();
+        assertEq(tokenProxy.delegates(_actor), newDelegations);
+        assertCorrectVotes(newDelegations, _amount);
+        // initial delegates should have 0 vote power (assuming set union is empty)
+        for (uint256 i = 0; i < delegations.length; i++) {
+            assertEq(
+                tokenProxy.getVotes(delegations[i]._delegatee),
+                0,
+                "initial delegate has vote power"
+            );
+        }
     }
 
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-    vm.expectRevert(
-      abi.encodeWithSelector(NumeratorSumExceedsDenominator.selector, sumOfNumerators, tokenProxy.DENOMINATOR())
-    );
-    tokenProxy.delegate(delegations);
-    vm.stopPrank();
-  }
+    function testFuzz_EmitsDelegateChangedEvents(
+        address _actor,
+        uint256 _amount,
+        uint256 _n,
+        uint256 _seed
+    ) public {
+        vm.assume(_actor != address(0));
+        _amount = bound(_amount, 0, type(uint208).max);
+        _n = bound(_n, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+        PartialDelegation[] memory delegations = _createValidPartialDelegation(
+            _n,
+            _seed
+        );
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+
+        vm.expectEmit();
+        emit DelegateChanged(_actor, new PartialDelegation[](0), delegations);
+        tokenProxy.delegate(delegations);
+        vm.stopPrank();
+    }
+
+    function testFuzz_EmitsDelegateVotesChanged(
+        address _actor,
+        uint256 _amount,
+        uint256 _n,
+        uint256 _seed
+    ) public {
+        vm.assume(_actor != address(0));
+        _amount = bound(_amount, 0, type(uint208).max);
+        _n = bound(_n, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+        PartialDelegation[] memory delegations = _createValidPartialDelegation(
+            _n,
+            _seed
+        );
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+
+        _expectEmitDelegateVotesChangedEvents(
+            _amount,
+            new PartialDelegation[](0),
+            delegations
+        );
+        tokenProxy.delegate(delegations);
+        vm.stopPrank();
+    }
+
+    function testFuzz_EmitsDelegateChangedEventsWhenDelegateesAreRemoved(
+        address _actor,
+        uint256 _amount,
+        uint256 _oldN,
+        uint256 _numOfDelegateesToRemove,
+        uint256 _seed
+    ) public {
+        vm.assume(_actor != address(0));
+        _amount = bound(_amount, 0, type(uint208).max);
+        _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+        _numOfDelegateesToRemove = bound(
+            _numOfDelegateesToRemove,
+            0,
+            _oldN - 1
+        );
+        PartialDelegation[]
+            memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+        tokenProxy.delegate(oldDelegations);
+
+        PartialDelegation[] memory newDelegations = new PartialDelegation[](
+            _oldN - _numOfDelegateesToRemove
+        );
+        for (uint256 i; i < newDelegations.length; i++) {
+            newDelegations[i] = oldDelegations[i];
+        }
+
+        vm.expectEmit();
+        emit DelegateChanged(_actor, oldDelegations, newDelegations);
+        tokenProxy.delegate(newDelegations);
+        vm.stopPrank();
+    }
+
+    function testFuzz_EmitsDelegateChangedEventsWhenAllNumeratorsForCurrentDelegateesAreChanged(
+        address _actor,
+        uint256 _amount,
+        uint256 _oldN,
+        uint256 _newN,
+        uint256 _seed
+    ) public {
+        vm.assume(_actor != address(0));
+        _amount = bound(_amount, 0, type(uint208).max);
+        _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+        _newN = bound(_newN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+        PartialDelegation[]
+            memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+        tokenProxy.delegate(oldDelegations);
+        PartialDelegation[] memory newDelegations = oldDelegations;
+
+        // Arthimatic overflow/underflow error without this bounding.
+        _seed = bound(
+            _seed,
+            1,
+            /* private key can't be bigger than secp256k1 curve order */
+            115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 -
+                1
+        );
+        uint96 _totalNumerator;
+        for (uint256 i = 0; i < _oldN; i++) {
+            uint96 _numerator = uint96(
+                bound(
+                    uint256(keccak256(abi.encode(_seed + i))) %
+                        tokenProxy.DENOMINATOR(), // initial value of the numerator
+                    1,
+                    tokenProxy.DENOMINATOR() - _totalNumerator - (_oldN - i) // ensure that there is enough numerator left for the
+                    // remaining delegations
+                )
+            );
+            newDelegations[i]._numerator = _numerator;
+            _totalNumerator += _numerator;
+        }
+
+        vm.expectEmit();
+        emit DelegateChanged(_actor, oldDelegations, newDelegations);
+        tokenProxy.delegate(newDelegations);
+        vm.stopPrank();
+    }
+
+    function testFuzz_EmitsDelegateChangedEventsWhenAllDelegatesAreReplaced(
+        address _actor,
+        uint256 _amount,
+        uint256 _oldN,
+        uint256 _newN,
+        uint256 _seed
+    ) public {
+        vm.assume(_actor != address(0));
+        _amount = bound(_amount, 0, type(uint208).max);
+        _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+        _newN = bound(_newN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+        PartialDelegation[]
+            memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+        tokenProxy.delegate(oldDelegations);
+
+        PartialDelegation[]
+            memory newDelegations = _createValidPartialDelegation(
+                _newN,
+                uint256(keccak256(abi.encode(_seed)))
+            );
+        vm.expectEmit();
+        emit DelegateChanged(_actor, oldDelegations, newDelegations);
+        tokenProxy.delegate(newDelegations);
+        vm.stopPrank();
+    }
+
+    function testFuzz_EmitsDelegateVotesChangedEventsWhenAllNumeratorsForCurrentDelegateesAreChanged(
+        address _actor,
+        uint256 _amount,
+        uint256 _oldN,
+        uint256 _newN,
+        uint256 _seed
+    ) public {
+        vm.assume(_actor != address(0));
+        _amount = bound(_amount, 0, type(uint208).max);
+        _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+        _newN = bound(_newN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+        PartialDelegation[]
+            memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+        tokenProxy.delegate(oldDelegations);
+        PartialDelegation[] memory newDelegations = oldDelegations;
+
+        _seed = bound(
+            _seed,
+            1,
+            /* private key can't be bigger than secp256k1 curve order */
+            115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 -
+                1
+        );
+        uint96 _totalNumerator;
+        for (uint256 i = 0; i < _oldN; i++) {
+            uint96 _numerator = uint96(
+                bound(
+                    uint256(keccak256(abi.encode(_seed + i))) %
+                        tokenProxy.DENOMINATOR(), // initial value of the numerator
+                    1,
+                    tokenProxy.DENOMINATOR() - _totalNumerator - (_oldN - i) // ensure that there is enough numerator left for the
+                    // remaining delegations
+                )
+            );
+            newDelegations[i]._numerator = _numerator;
+            _totalNumerator += _numerator;
+        }
+
+        _expectEmitDelegateVotesChangedEvents(
+            _amount,
+            oldDelegations,
+            newDelegations
+        );
+        tokenProxy.delegate(newDelegations);
+        vm.stopPrank();
+    }
+
+    function testFuzz_EmitsDelegateVotesChangedEventsWhenDelegateesAreRemoved(
+        address _actor,
+        uint256 _amount,
+        uint256 _oldN,
+        uint256 _numOfDelegateesToRemove,
+        uint256 _seed
+    ) public {
+        vm.assume(_actor != address(0));
+        _amount = bound(_amount, 0, type(uint208).max);
+        _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+        _numOfDelegateesToRemove = bound(
+            _numOfDelegateesToRemove,
+            0,
+            _oldN - 1
+        );
+        PartialDelegation[]
+            memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+        tokenProxy.delegate(oldDelegations);
+
+        PartialDelegation[] memory newDelegations = new PartialDelegation[](
+            _oldN - _numOfDelegateesToRemove
+        );
+        for (uint256 i; i < newDelegations.length; i++) {
+            newDelegations[i] = oldDelegations[i];
+        }
+
+        _expectEmitDelegateVotesChangedEvents(
+            _amount,
+            oldDelegations,
+            newDelegations
+        );
+        tokenProxy.delegate(newDelegations);
+        vm.stopPrank();
+    }
+
+    function testFuzz_EmitsDelegateVotesChangedEventsWhenAllDelegatesAreReplaced(
+        address _actor,
+        uint256 _amount,
+        uint256 _oldN,
+        uint256 _newN,
+        uint256 _seed
+    ) public {
+        vm.assume(_actor != address(0));
+        _amount = bound(_amount, 0, type(uint208).max);
+        _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+        _newN = bound(_newN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+
+        PartialDelegation[]
+            memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+        tokenProxy.delegate(oldDelegations);
+
+        PartialDelegation[]
+            memory newDelegations = _createValidPartialDelegation(
+                _newN,
+                uint256(keccak256(abi.encode(_seed)))
+            );
+        _expectEmitDelegateVotesChangedEvents(
+            _amount,
+            oldDelegations,
+            newDelegations
+        );
+        tokenProxy.delegate(newDelegations);
+        vm.stopPrank();
+    }
+
+    function testFuzz_RevertIf_DelegationArrayIncludesDuplicates(
+        address _actor,
+        address _delegatee,
+        uint256 _amount,
+        uint96 _numerator
+    ) public {
+        vm.assume(_actor != address(0));
+        vm.assume(_delegatee != address(0));
+        _amount = bound(_amount, 0, type(uint208).max);
+        _numerator = uint96(bound(_numerator, 1, tokenProxy.DENOMINATOR() - 1));
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+        PartialDelegation[] memory delegations = new PartialDelegation[](2);
+        delegations[0] = PartialDelegation(_delegatee, _numerator);
+        delegations[1] = PartialDelegation(
+            _delegatee,
+            tokenProxy.DENOMINATOR() - _numerator
+        );
+        vm.expectRevert();
+        tokenProxy.delegate(delegations);
+        vm.stopPrank();
+    }
+
+    function testFuzz_RevertIf_DelegationArrayNumeratorsSumToGreaterThanDenominator(
+        address _actor,
+        address _delegatee1,
+        address _delegatee2,
+        uint256 _amount,
+        uint96 _numerator1,
+        uint96 _numerator2
+    ) public {
+        vm.assume(_actor != address(0));
+        vm.assume(_delegatee1 != address(0));
+        vm.assume(_delegatee2 != address(0));
+        vm.assume(_delegatee1 < _delegatee2);
+        _amount = bound(_amount, 0, type(uint208).max);
+        _numerator1 = uint96(bound(_numerator1, 1, tokenProxy.DENOMINATOR()));
+        _numerator2 = uint96(
+            bound(
+                _numerator2,
+                tokenProxy.DENOMINATOR() - _numerator1 + 1,
+                type(uint96).max - _numerator1
+            )
+        );
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+        PartialDelegation[] memory delegations = new PartialDelegation[](2);
+        delegations[0] = PartialDelegation(_delegatee1, _numerator1);
+        delegations[1] = PartialDelegation(_delegatee2, _numerator2);
+        vm.expectRevert();
+        tokenProxy.delegate(delegations);
+        vm.stopPrank();
+    }
+
+    function testFuzz_RevertIf_DelegationNumeratorTooLarge(
+        address _actor,
+        address _delegatee,
+        uint256 _amount,
+        uint96 _numerator
+    ) public {
+        vm.assume(_actor != address(0));
+        vm.assume(_delegatee != address(0));
+        _numerator = uint96(
+            bound(_numerator, tokenProxy.DENOMINATOR() + 1, type(uint96).max)
+        );
+        _amount = bound(_amount, 0, type(uint208).max);
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+        PartialDelegation[] memory delegations = new PartialDelegation[](1);
+        delegations[0] = PartialDelegation(_delegatee, _numerator);
+        vm.expectRevert();
+        tokenProxy.delegate(delegations);
+        vm.stopPrank();
+    }
+
+    function testFuzz_RevertIf_PartialDelegationLimitExceeded(
+        address _actor,
+        uint256 _amount,
+        uint256 _numOfDelegatees,
+        uint256 _seed
+    ) public {
+        vm.assume(_actor != address(0));
+        _amount = bound(_amount, 0, type(uint208).max);
+        _numOfDelegatees = bound(
+            _numOfDelegatees,
+            tokenProxy.MAX_PARTIAL_DELEGATIONS() + 1,
+            tokenProxy.MAX_PARTIAL_DELEGATIONS() + 500
+        );
+        PartialDelegation[] memory delegations = _createValidPartialDelegation(
+            _numOfDelegatees,
+            _seed
+        );
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                PartialDelegationLimitExceeded.selector,
+                _numOfDelegatees,
+                tokenProxy.MAX_PARTIAL_DELEGATIONS()
+            )
+        );
+        tokenProxy.delegate(delegations);
+        vm.stopPrank();
+    }
+
+    function testFuzz_RevertIf_DuplicateOrUnsortedDelegatees(
+        address _actor,
+        uint256 _amount,
+        uint256 _numOfDelegatees,
+        address _replacedDelegatee,
+        uint256 _seed
+    ) public {
+        vm.assume(_actor != address(0));
+        _amount = bound(_amount, 0, type(uint208).max);
+        _numOfDelegatees = bound(
+            _numOfDelegatees,
+            2,
+            tokenProxy.MAX_PARTIAL_DELEGATIONS()
+        );
+        PartialDelegation[] memory delegations = _createValidPartialDelegation(
+            _numOfDelegatees,
+            _seed
+        );
+        address lastDelegatee = delegations[delegations.length - 1]._delegatee;
+        vm.assume(_replacedDelegatee <= lastDelegatee);
+        delegations[delegations.length - 1]._delegatee = _replacedDelegatee;
+
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                DuplicateOrUnsortedDelegatees.selector,
+                _replacedDelegatee
+            )
+        );
+        tokenProxy.delegate(delegations);
+        vm.stopPrank();
+    }
+
+    function testFuzz_RevertIf_InvalidNumeratorZero(
+        address _actor,
+        uint256 _amount,
+        uint256 _delegationIndex,
+        uint256 _seed
+    ) public {
+        vm.assume(_actor != address(0));
+        _amount = bound(_amount, 0, type(uint208).max);
+        PartialDelegation[] memory delegations = _createValidPartialDelegation(
+            0,
+            _seed
+        );
+        _delegationIndex = bound(_delegationIndex, 0, delegations.length - 1);
+
+        delegations[_delegationIndex]._numerator = 0;
+
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+        vm.expectRevert(InvalidNumeratorZero.selector);
+        tokenProxy.delegate(delegations);
+        vm.stopPrank();
+    }
+
+    function testFuzz_RevertIf_NumeratorSumExceedsDenominator(
+        address _actor,
+        uint256 _amount,
+        uint256 _delegationIndex,
+        uint256 _seed
+    ) public {
+        vm.assume(_actor != address(0));
+        _amount = bound(_amount, 0, type(uint208).max);
+        PartialDelegation[] memory delegations = _createValidPartialDelegation(
+            0,
+            _seed
+        );
+        _delegationIndex = bound(_delegationIndex, 0, delegations.length - 1);
+
+        delegations[_delegationIndex]._numerator = tokenProxy.DENOMINATOR() + 1;
+        uint256 sumOfNumerators;
+        for (uint256 i; i < delegations.length; i++) {
+            sumOfNumerators += delegations[i]._numerator;
+        }
+
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                NumeratorSumExceedsDenominator.selector,
+                sumOfNumerators,
+                tokenProxy.DENOMINATOR()
+            )
+        );
+        tokenProxy.delegate(delegations);
+        vm.stopPrank();
+    }
 }
 
 contract DelegateLegacy is PartialDelegationTest {
-  function testFuzz_DelegatesSuccessfullyToNonZeroAddress(
-    uint256 _delegatorPrivateKey,
-    address _delegatee,
-    uint256 _delegatorBalance,
-    uint256 _deadline
-  ) public {
-    vm.assume(_delegatee != address(0));
-    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-    address _delegator = vm.addr(_delegatorPrivateKey);
-    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-    _mint(_delegator, _delegatorBalance);
+    function testFuzz_DelegatesSuccessfullyToNonZeroAddress(
+        uint256 _delegatorPrivateKey,
+        address _delegatee,
+        uint256 _delegatorBalance,
+        uint256 _deadline
+    ) public {
+        vm.assume(_delegatee != address(0));
+        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+        address _delegator = vm.addr(_delegatorPrivateKey);
+        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+        _mint(_delegator, _delegatorBalance);
 
-    vm.prank(_delegator);
-    tokenProxy.delegate(_delegatee);
-    assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_delegatee));
-    assertEq(tokenProxy.getVotes(_delegatee), _delegatorBalance);
-  }
+        vm.prank(_delegator);
+        tokenProxy.delegate(_delegatee);
+        assertEq(
+            tokenProxy.delegates(_delegator),
+            _createSingleFullDelegation(_delegatee)
+        );
+        assertEq(tokenProxy.getVotes(_delegatee), _delegatorBalance);
+    }
 
-  function testFuzz_DelegatesSuccessfullyToZeroAddress(
-    uint256 _delegatorPrivateKey,
-    uint256 _delegatorBalance,
-    uint256 _deadline
-  ) public {
-    address _delegatee = address(0);
-    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-    address _delegator = vm.addr(_delegatorPrivateKey);
-    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-    _mint(_delegator, _delegatorBalance);
+    function testFuzz_DelegatesSuccessfullyToZeroAddress(
+        uint256 _delegatorPrivateKey,
+        uint256 _delegatorBalance,
+        uint256 _deadline
+    ) public {
+        address _delegatee = address(0);
+        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+        address _delegator = vm.addr(_delegatorPrivateKey);
+        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+        _mint(_delegator, _delegatorBalance);
 
-    vm.prank(_delegator);
-    tokenProxy.delegate(_delegatee);
-    assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_delegatee));
-    assertEq(tokenProxy.getVotes(_delegatee), 0);
-  }
+        vm.prank(_delegator);
+        tokenProxy.delegate(_delegatee);
+        assertEq(
+            tokenProxy.delegates(_delegator),
+            _createSingleFullDelegation(_delegatee)
+        );
+        assertEq(tokenProxy.getVotes(_delegatee), 0);
+    }
 
-  function testFuzz_RedelegatesSuccessfully(
-    uint256 _delegatorPrivateKey,
-    address _delegatee,
-    address _newDelegatee,
-    uint256 _delegatorBalance,
-    uint256 _deadline
-  ) public {
-    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-    address _delegator = vm.addr(_delegatorPrivateKey);
-    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-    _mint(_delegator, _delegatorBalance);
+    function testFuzz_RedelegatesSuccessfully(
+        uint256 _delegatorPrivateKey,
+        address _delegatee,
+        address _newDelegatee,
+        uint256 _delegatorBalance,
+        uint256 _deadline
+    ) public {
+        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+        address _delegator = vm.addr(_delegatorPrivateKey);
+        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+        _mint(_delegator, _delegatorBalance);
 
-    vm.prank(_delegator);
-    tokenProxy.delegate(_delegatee);
-    assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_delegatee));
-    uint256 _expectedVotes = _delegatee == address(0) ? 0 : _delegatorBalance;
-    assertEq(tokenProxy.getVotes(_delegatee), _expectedVotes);
+        vm.prank(_delegator);
+        tokenProxy.delegate(_delegatee);
+        assertEq(
+            tokenProxy.delegates(_delegator),
+            _createSingleFullDelegation(_delegatee)
+        );
+        uint256 _expectedVotes = _delegatee == address(0)
+            ? 0
+            : _delegatorBalance;
+        assertEq(tokenProxy.getVotes(_delegatee), _expectedVotes);
 
-    vm.prank(_delegator);
-    tokenProxy.delegate(_newDelegatee);
-    assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_newDelegatee));
-    _expectedVotes = _newDelegatee == address(0) ? 0 : _delegatorBalance;
-    assertEq(tokenProxy.getVotes(_newDelegatee), _expectedVotes);
-  }
+        vm.prank(_delegator);
+        tokenProxy.delegate(_newDelegatee);
+        assertEq(
+            tokenProxy.delegates(_delegator),
+            _createSingleFullDelegation(_newDelegatee)
+        );
+        _expectedVotes = _newDelegatee == address(0) ? 0 : _delegatorBalance;
+        assertEq(tokenProxy.getVotes(_newDelegatee), _expectedVotes);
+    }
 
-  function testFuzz_RedelegatesToAPartialDelegationSuccessfully(
-    uint256 _delegatorPrivateKey,
-    address _delegatee,
-    uint256 _delegatorBalance,
-    uint256 _deadline,
-    uint256 _seed
-  ) public {
-    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-    address _delegator = vm.addr(_delegatorPrivateKey);
-    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-    _mint(_delegator, _delegatorBalance);
+    function testFuzz_RedelegatesToAPartialDelegationSuccessfully(
+        uint256 _delegatorPrivateKey,
+        address _delegatee,
+        uint256 _delegatorBalance,
+        uint256 _deadline,
+        uint256 _seed
+    ) public {
+        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+        address _delegator = vm.addr(_delegatorPrivateKey);
+        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+        _mint(_delegator, _delegatorBalance);
 
-    vm.prank(_delegator);
-    tokenProxy.delegate(_delegatee);
-    assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_delegatee));
-    uint256 _expectedVotes = _delegatee == address(0) ? 0 : _delegatorBalance;
-    assertEq(tokenProxy.getVotes(_delegatee), _expectedVotes);
+        vm.prank(_delegator);
+        tokenProxy.delegate(_delegatee);
+        assertEq(
+            tokenProxy.delegates(_delegator),
+            _createSingleFullDelegation(_delegatee)
+        );
+        uint256 _expectedVotes = _delegatee == address(0)
+            ? 0
+            : _delegatorBalance;
+        assertEq(tokenProxy.getVotes(_delegatee), _expectedVotes);
 
-    PartialDelegation[] memory newDelegations = _createValidPartialDelegation(0, uint256(keccak256(abi.encode(_seed))));
-    vm.prank(_delegator);
-    tokenProxy.delegate(newDelegations);
-    assertEq(tokenProxy.delegates(_delegator), newDelegations);
-    assertCorrectVotes(newDelegations, _delegatorBalance);
-  }
+        PartialDelegation[]
+            memory newDelegations = _createValidPartialDelegation(
+                0,
+                uint256(keccak256(abi.encode(_seed)))
+            );
+        vm.prank(_delegator);
+        tokenProxy.delegate(newDelegations);
+        assertEq(tokenProxy.delegates(_delegator), newDelegations);
+        assertCorrectVotes(newDelegations, _delegatorBalance);
+    }
 }
 
 contract DelegateBySig is PartialDelegationTest {
-  using stdStorage for StdStorage;
+    using stdStorage for StdStorage;
 
-  function testFuzz_DelegatesSuccessfullyToNonZeroAddress(
-    address _actor,
-    uint256 _delegatorPrivateKey,
-    address _delegatee,
-    uint256 _delegatorBalance,
-    uint256 _currentNonce,
-    uint256 _deadline
-  ) public {
-    vm.assume(_actor != address(0));
-    vm.assume(_delegatee != address(0));
-    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-    address _delegator = vm.addr(_delegatorPrivateKey);
-    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_delegator).checked_write(_currentNonce);
-    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-    _mint(_delegator, _delegatorBalance);
+    function testFuzz_DelegatesSuccessfullyToNonZeroAddress(
+        address _actor,
+        uint256 _delegatorPrivateKey,
+        address _delegatee,
+        uint256 _delegatorBalance,
+        uint256 _currentNonce,
+        uint256 _deadline
+    ) public {
+        vm.assume(_actor != address(0));
+        vm.assume(_delegatee != address(0));
+        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+        address _delegator = vm.addr(_delegatorPrivateKey);
+        stdstore
+            .target(address(tokenProxy))
+            .sig("nonces(address)")
+            .with_key(_delegator)
+            .checked_write(_currentNonce);
+        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+        _mint(_delegator, _delegatorBalance);
 
-    bytes32 _message = keccak256(abi.encode(tokenProxy.DELEGATION_TYPEHASH(), _delegatee, _currentNonce, _deadline));
+        bytes32 _message = keccak256(
+            abi.encode(
+                tokenProxy.DELEGATION_TYPEHASH(),
+                _delegatee,
+                _currentNonce,
+                _deadline
+            )
+        );
 
-    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
-    (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_delegatorPrivateKey, _messageHash);
-    vm.prank(_actor);
-    tokenProxy.delegateBySig(_delegatee, _currentNonce, _deadline, _v, _r, _s);
-    assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_delegatee));
-    assertEq(tokenProxy.getVotes(_delegatee), _delegatorBalance);
-  }
-
-  function testFuzz_DelegatesSuccessfullyToZeroAddress(
-    address _actor,
-    uint256 _delegatorPrivateKey,
-    uint256 _delegatorBalance,
-    uint256 _currentNonce,
-    uint256 _deadline
-  ) public {
-    vm.assume(_actor != address(0));
-    address _delegatee = address(0);
-    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-    address _delegator = vm.addr(_delegatorPrivateKey);
-    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_delegator).checked_write(_currentNonce);
-    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-    _mint(_delegator, _delegatorBalance);
-
-    bytes32 _message = keccak256(abi.encode(tokenProxy.DELEGATION_TYPEHASH(), address(0), _currentNonce, _deadline));
-
-    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
-    (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_delegatorPrivateKey, _messageHash);
-    vm.prank(_actor);
-    tokenProxy.delegateBySig(_delegatee, _currentNonce, _deadline, _v, _r, _s);
-    assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_delegatee));
-    assertEq(tokenProxy.getVotes(_delegatee), 0);
-  }
-
-  function testFuzz_RevertIf_DelegatesViaERC712SignatureWithExpiredDeadline(
-    address _actor,
-    uint256 _delegatorPrivateKey,
-    address _delegatee,
-    uint256 _delegatorBalance,
-    uint256 _currentNonce,
-    uint256 _currentTimestamp,
-    uint256 _deadline
-  ) public {
-    vm.assume(_actor != address(0));
-    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-    address _delegator = vm.addr(_delegatorPrivateKey);
-    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_delegator).checked_write(_currentNonce);
-    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-    _currentTimestamp = bound(_currentTimestamp, 1, type(uint256).max);
-    vm.warp(_currentTimestamp);
-    _deadline = bound(_deadline, 0, _currentTimestamp - 1);
-    _mint(_delegator, _delegatorBalance);
-
-    bytes32 _message = keccak256(abi.encode(tokenProxy.DELEGATION_TYPEHASH(), _delegatee, _currentNonce, _deadline));
-
-    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
-    (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_delegatorPrivateKey, _messageHash);
-    vm.prank(_actor);
-    vm.expectRevert(abi.encodeWithSelector(VotesExpiredSignature.selector, _deadline));
-    tokenProxy.delegateBySig(_delegatee, _currentNonce, _deadline, _v, _r, _s);
-  }
-
-  function testFuzz_RevertIf_DelegatesViaERC712SignatureWithWrongNonce(
-    address _actor,
-    uint256 _delegatorPrivateKey,
-    address _delegatee,
-    uint256 _delegatorBalance,
-    uint256 _currentNonce,
-    uint256 _suppliedNonce,
-    uint256 _deadline
-  ) public {
-    vm.assume(_actor != address(0));
-    vm.assume(_suppliedNonce != _currentNonce);
-    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-    address _delegator = vm.addr(_delegatorPrivateKey);
-    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_delegator).checked_write(_currentNonce);
-    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-    _mint(_delegator, _delegatorBalance);
-
-    bytes32 _message = keccak256(abi.encode(tokenProxy.DELEGATION_TYPEHASH(), _delegatee, _suppliedNonce, _deadline));
-
-    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
-    (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_delegatorPrivateKey, _messageHash);
-    vm.prank(_actor);
-    vm.expectRevert(abi.encodeWithSelector(InvalidAccountNonce.selector, _delegator, tokenProxy.nonces(_delegator)));
-    tokenProxy.delegateBySig(_delegatee, _suppliedNonce, _deadline, _v, _r, _s);
-  }
-
-  function testFuzz_RevertIf_DelegatesViaInvalidERC712Signature(
-    address _actor,
-    uint256 _delegatorPrivateKey,
-    address _delegatee,
-    uint256 _delegatorBalance,
-    uint256 _currentNonce,
-    uint256 _deadline,
-    uint256 _randomSeed
-  ) public {
-    vm.assume(_actor != address(0));
-    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-    address _delegator = vm.addr(_delegatorPrivateKey);
-    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_delegator).checked_write(_currentNonce);
-    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-    _mint(_delegator, _delegatorBalance);
-
-    bytes32 _message = keccak256(abi.encode(tokenProxy.DELEGATION_TYPEHASH(), _delegatee, _currentNonce, _deadline));
-    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
-
-    // Here we use `_randomSeed` as an arbitrary source of randomness to replace a legit parameter
-    // with an attack-like one.
-    if (_randomSeed % 3 == 0) {
-      _delegatee = address(uint160(uint256(keccak256(abi.encode(_delegatee)))));
-    } else if (_randomSeed % 3 == 1) {
-      _currentNonce = uint256(keccak256(abi.encode(_currentNonce)));
-    }
-    (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_delegatorPrivateKey, _messageHash);
-    if (_randomSeed % 3 == 2) {
-      (_v, _r, _s) = vm.sign(uint256(keccak256(abi.encode(_delegatorPrivateKey))), _messageHash);
+        bytes32 _messageHash = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
+        );
+        (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(
+            _delegatorPrivateKey,
+            _messageHash
+        );
+        vm.prank(_actor);
+        tokenProxy.delegateBySig(
+            _delegatee,
+            _currentNonce,
+            _deadline,
+            _v,
+            _r,
+            _s
+        );
+        assertEq(
+            tokenProxy.delegates(_delegator),
+            _createSingleFullDelegation(_delegatee)
+        );
+        assertEq(tokenProxy.getVotes(_delegatee), _delegatorBalance);
     }
 
-    vm.prank(_actor);
-    try tokenProxy.delegateBySig(_delegatee, _currentNonce, _deadline, _v, _r, _s) {} catch {}
-    assertEq(tokenProxy.delegates(_delegator), new PartialDelegation[](0));
-  }
+    function testFuzz_DelegatesSuccessfullyToZeroAddress(
+        address _actor,
+        uint256 _delegatorPrivateKey,
+        uint256 _delegatorBalance,
+        uint256 _currentNonce,
+        uint256 _deadline
+    ) public {
+        vm.assume(_actor != address(0));
+        address _delegatee = address(0);
+        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+        address _delegator = vm.addr(_delegatorPrivateKey);
+        stdstore
+            .target(address(tokenProxy))
+            .sig("nonces(address)")
+            .with_key(_delegator)
+            .checked_write(_currentNonce);
+        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+        _mint(_delegator, _delegatorBalance);
+
+        bytes32 _message = keccak256(
+            abi.encode(
+                tokenProxy.DELEGATION_TYPEHASH(),
+                address(0),
+                _currentNonce,
+                _deadline
+            )
+        );
+
+        bytes32 _messageHash = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
+        );
+        (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(
+            _delegatorPrivateKey,
+            _messageHash
+        );
+        vm.prank(_actor);
+        tokenProxy.delegateBySig(
+            _delegatee,
+            _currentNonce,
+            _deadline,
+            _v,
+            _r,
+            _s
+        );
+        assertEq(
+            tokenProxy.delegates(_delegator),
+            _createSingleFullDelegation(_delegatee)
+        );
+        assertEq(tokenProxy.getVotes(_delegatee), 0);
+    }
+
+    function testFuzz_RevertIf_DelegatesViaERC712SignatureWithExpiredDeadline(
+        address _actor,
+        uint256 _delegatorPrivateKey,
+        address _delegatee,
+        uint256 _delegatorBalance,
+        uint256 _currentNonce,
+        uint256 _currentTimestamp,
+        uint256 _deadline
+    ) public {
+        vm.assume(_actor != address(0));
+        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+        address _delegator = vm.addr(_delegatorPrivateKey);
+        stdstore
+            .target(address(tokenProxy))
+            .sig("nonces(address)")
+            .with_key(_delegator)
+            .checked_write(_currentNonce);
+        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+        _currentTimestamp = bound(_currentTimestamp, 1, type(uint256).max);
+        vm.warp(_currentTimestamp);
+        _deadline = bound(_deadline, 0, _currentTimestamp - 1);
+        _mint(_delegator, _delegatorBalance);
+
+        bytes32 _message = keccak256(
+            abi.encode(
+                tokenProxy.DELEGATION_TYPEHASH(),
+                _delegatee,
+                _currentNonce,
+                _deadline
+            )
+        );
+
+        bytes32 _messageHash = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
+        );
+        (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(
+            _delegatorPrivateKey,
+            _messageHash
+        );
+        vm.prank(_actor);
+        vm.expectRevert(
+            abi.encodeWithSelector(VotesExpiredSignature.selector, _deadline)
+        );
+        tokenProxy.delegateBySig(
+            _delegatee,
+            _currentNonce,
+            _deadline,
+            _v,
+            _r,
+            _s
+        );
+    }
+
+    function testFuzz_RevertIf_DelegatesViaERC712SignatureWithWrongNonce(
+        address _actor,
+        uint256 _delegatorPrivateKey,
+        address _delegatee,
+        uint256 _delegatorBalance,
+        uint256 _currentNonce,
+        uint256 _suppliedNonce,
+        uint256 _deadline
+    ) public {
+        vm.assume(_actor != address(0));
+        vm.assume(_suppliedNonce != _currentNonce);
+        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+        address _delegator = vm.addr(_delegatorPrivateKey);
+        stdstore
+            .target(address(tokenProxy))
+            .sig("nonces(address)")
+            .with_key(_delegator)
+            .checked_write(_currentNonce);
+        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+        _mint(_delegator, _delegatorBalance);
+
+        bytes32 _message = keccak256(
+            abi.encode(
+                tokenProxy.DELEGATION_TYPEHASH(),
+                _delegatee,
+                _suppliedNonce,
+                _deadline
+            )
+        );
+
+        bytes32 _messageHash = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
+        );
+        (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(
+            _delegatorPrivateKey,
+            _messageHash
+        );
+        vm.prank(_actor);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                InvalidAccountNonce.selector,
+                _delegator,
+                tokenProxy.nonces(_delegator)
+            )
+        );
+        tokenProxy.delegateBySig(
+            _delegatee,
+            _suppliedNonce,
+            _deadline,
+            _v,
+            _r,
+            _s
+        );
+    }
+
+    function testFuzz_RevertIf_DelegatesViaInvalidERC712Signature(
+        address _actor,
+        uint256 _delegatorPrivateKey,
+        address _delegatee,
+        uint256 _delegatorBalance,
+        uint256 _currentNonce,
+        uint256 _deadline,
+        uint256 _randomSeed
+    ) public {
+        vm.assume(_actor != address(0));
+        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+        address _delegator = vm.addr(_delegatorPrivateKey);
+        stdstore
+            .target(address(tokenProxy))
+            .sig("nonces(address)")
+            .with_key(_delegator)
+            .checked_write(_currentNonce);
+        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+        _mint(_delegator, _delegatorBalance);
+
+        bytes32 _message = keccak256(
+            abi.encode(
+                tokenProxy.DELEGATION_TYPEHASH(),
+                _delegatee,
+                _currentNonce,
+                _deadline
+            )
+        );
+        bytes32 _messageHash = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
+        );
+
+        // Here we use `_randomSeed` as an arbitrary source of randomness to replace a legit parameter
+        // with an attack-like one.
+        if (_randomSeed % 3 == 0) {
+            _delegatee = address(
+                uint160(uint256(keccak256(abi.encode(_delegatee))))
+            );
+        } else if (_randomSeed % 3 == 1) {
+            _currentNonce = uint256(keccak256(abi.encode(_currentNonce)));
+        }
+        (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(
+            _delegatorPrivateKey,
+            _messageHash
+        );
+        if (_randomSeed % 3 == 2) {
+            (_v, _r, _s) = vm.sign(
+                uint256(keccak256(abi.encode(_delegatorPrivateKey))),
+                _messageHash
+            );
+        }
+
+        vm.prank(_actor);
+        try
+            tokenProxy.delegateBySig(
+                _delegatee,
+                _currentNonce,
+                _deadline,
+                _v,
+                _r,
+                _s
+            )
+        {} catch {}
+        assertEq(tokenProxy.delegates(_delegator), new PartialDelegation[](0));
+    }
 }
 
 contract DelegatePartiallyOnBehalf is PartialDelegationTest {
-  using stdStorage for StdStorage;
+    using stdStorage for StdStorage;
 
-  function testFuzz_DelegatesSuccessfullyViaERC712Signer(
-    address _actor,
-    uint256 _delegatorPrivateKey,
-    uint256 _delegationSeed,
-    uint256 _delegatorBalance,
-    uint256 _currentNonce,
-    uint256 _deadline
-  ) public {
-    vm.assume(_actor != address(0));
-    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-    address _delegator = vm.addr(_delegatorPrivateKey);
-    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_delegator).checked_write(_currentNonce);
-    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-    _mint(_delegator, _delegatorBalance);
+    function testFuzz_DelegatesSuccessfullyViaERC712Signer(
+        address _actor,
+        uint256 _delegatorPrivateKey,
+        uint256 _delegationSeed,
+        uint256 _delegatorBalance,
+        uint256 _currentNonce,
+        uint256 _deadline
+    ) public {
+        vm.assume(_actor != address(0));
+        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+        address _delegator = vm.addr(_delegatorPrivateKey);
+        stdstore
+            .target(address(tokenProxy))
+            .sig("nonces(address)")
+            .with_key(_delegator)
+            .checked_write(_currentNonce);
+        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+        _mint(_delegator, _delegatorBalance);
 
-    PartialDelegation[] memory _delegations = _createValidPartialDelegation(0, _delegationSeed);
+        PartialDelegation[] memory _delegations = _createValidPartialDelegation(
+            0,
+            _delegationSeed
+        );
 
-    bytes32[] memory _payload = new bytes32[](_delegations.length);
-    for (uint256 i; i < _delegations.length; i++) {
-      _payload[i] = _hash(_delegations[i]);
+        bytes32[] memory _payload = new bytes32[](_delegations.length);
+        for (uint256 i; i < _delegations.length; i++) {
+            _payload[i] = _hash(_delegations[i]);
+        }
+
+        bytes32 _message = keccak256(
+            abi.encode(
+                tokenProxy.PARTIAL_DELEGATION_ON_BEHALF_TYPEHASH(),
+                _delegator,
+                keccak256(abi.encodePacked(_payload)),
+                _currentNonce,
+                _deadline
+            )
+        );
+
+        bytes32 _messageHash = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
+        );
+        bytes memory _signature = _sign(_delegatorPrivateKey, _messageHash);
+        vm.prank(_actor);
+        tokenProxy.delegatePartiallyOnBehalf(
+            _delegator,
+            _delegations,
+            _currentNonce,
+            _deadline,
+            _signature
+        );
+        assertEq(tokenProxy.delegates(_delegator), _delegations);
     }
 
-    bytes32 _message = keccak256(
-      abi.encode(
-        tokenProxy.PARTIAL_DELEGATION_ON_BEHALF_TYPEHASH(),
-        _delegator,
-        keccak256(abi.encodePacked(_payload)),
-        _currentNonce,
-        _deadline
-      )
-    );
+    function testFuzz_DelegatesSuccessfullyViaERC1271Signer(
+        address _actor,
+        uint256 _delegationSeed,
+        uint256 _delegatorBalance,
+        uint256 _currentNonce,
+        uint256 _deadline,
+        bytes memory _signature
+    ) public {
+        vm.assume(_actor != address(0));
+        MockERC1271Signer _erc1271Signer = new MockERC1271Signer();
+        _erc1271Signer.setResponse__isValidSignature(true);
+        address _delegator = address(_erc1271Signer);
+        stdstore
+            .target(address(tokenProxy))
+            .sig("nonces(address)")
+            .with_key(address(_delegator))
+            .checked_write(_currentNonce);
+        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+        _mint(_delegator, _delegatorBalance);
 
-    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
-    bytes memory _signature = _sign(_delegatorPrivateKey, _messageHash);
-    vm.prank(_actor);
-    tokenProxy.delegatePartiallyOnBehalf(_delegator, _delegations, _currentNonce, _deadline, _signature);
-    assertEq(tokenProxy.delegates(_delegator), _delegations);
-  }
+        PartialDelegation[] memory _delegations = _createValidPartialDelegation(
+            0,
+            _delegationSeed
+        );
 
-  function testFuzz_DelegatesSuccessfullyViaERC1271Signer(
-    address _actor,
-    uint256 _delegationSeed,
-    uint256 _delegatorBalance,
-    uint256 _currentNonce,
-    uint256 _deadline,
-    bytes memory _signature
-  ) public {
-    vm.assume(_actor != address(0));
-    MockERC1271Signer _erc1271Signer = new MockERC1271Signer();
-    _erc1271Signer.setResponse__isValidSignature(true);
-    address _delegator = address(_erc1271Signer);
-    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(address(_delegator)).checked_write(
-      _currentNonce
-    );
-    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-    _mint(_delegator, _delegatorBalance);
+        bytes32[] memory _payload = new bytes32[](_delegations.length);
+        for (uint256 i; i < _delegations.length; i++) {
+            _payload[i] = _hash(_delegations[i]);
+        }
 
-    PartialDelegation[] memory _delegations = _createValidPartialDelegation(0, _delegationSeed);
-
-    bytes32[] memory _payload = new bytes32[](_delegations.length);
-    for (uint256 i; i < _delegations.length; i++) {
-      _payload[i] = _hash(_delegations[i]);
+        vm.prank(_actor);
+        tokenProxy.delegatePartiallyOnBehalf(
+            _delegator,
+            _delegations,
+            _currentNonce,
+            _deadline,
+            _signature
+        );
+        assertEq(tokenProxy.delegates(_delegator), _delegations);
     }
 
-    vm.prank(_actor);
-    tokenProxy.delegatePartiallyOnBehalf(_delegator, _delegations, _currentNonce, _deadline, _signature);
-    assertEq(tokenProxy.delegates(_delegator), _delegations);
-  }
+    function testFuzz_RevertIf_DelegatesViaERC712SignerWithWrongNonce(
+        address _actor,
+        uint256 _delegatorPrivateKey,
+        uint256 _delegationSeed,
+        uint256 _delegatorBalance,
+        uint256 _currentNonce,
+        uint256 _suppliedNonce,
+        uint256 _deadline
+    ) public {
+        vm.assume(_actor != address(0));
+        vm.assume(_suppliedNonce != _currentNonce);
+        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+        address _delegator = vm.addr(_delegatorPrivateKey);
+        stdstore
+            .target(address(tokenProxy))
+            .sig("nonces(address)")
+            .with_key(_delegator)
+            .checked_write(_currentNonce);
+        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+        _mint(_delegator, _delegatorBalance);
 
-  function testFuzz_RevertIf_DelegatesViaERC712SignerWithWrongNonce(
-    address _actor,
-    uint256 _delegatorPrivateKey,
-    uint256 _delegationSeed,
-    uint256 _delegatorBalance,
-    uint256 _currentNonce,
-    uint256 _suppliedNonce,
-    uint256 _deadline
-  ) public {
-    vm.assume(_actor != address(0));
-    vm.assume(_suppliedNonce != _currentNonce);
-    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-    address _delegator = vm.addr(_delegatorPrivateKey);
-    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_delegator).checked_write(_currentNonce);
-    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-    _mint(_delegator, _delegatorBalance);
+        PartialDelegation[] memory _delegations = _createValidPartialDelegation(
+            0,
+            _delegationSeed
+        );
 
-    PartialDelegation[] memory _delegations = _createValidPartialDelegation(0, _delegationSeed);
+        bytes32[] memory _payload = new bytes32[](_delegations.length);
+        for (uint256 i; i < _delegations.length; i++) {
+            _payload[i] = _hash(_delegations[i]);
+        }
 
-    bytes32[] memory _payload = new bytes32[](_delegations.length);
-    for (uint256 i; i < _delegations.length; i++) {
-      _payload[i] = _hash(_delegations[i]);
+        bytes32 _message = keccak256(
+            abi.encode(
+                tokenProxy.PARTIAL_DELEGATION_ON_BEHALF_TYPEHASH(),
+                _delegator,
+                keccak256(abi.encodePacked(_payload)),
+                _suppliedNonce,
+                _deadline
+            )
+        );
+
+        bytes32 _messageHash = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
+        );
+        bytes memory _signature = _sign(_delegatorPrivateKey, _messageHash);
+        vm.prank(_actor);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                InvalidAccountNonce.selector,
+                _delegator,
+                tokenProxy.nonces(_delegator)
+            )
+        );
+        tokenProxy.delegatePartiallyOnBehalf(
+            _delegator,
+            _delegations,
+            _suppliedNonce,
+            _deadline,
+            _signature
+        );
     }
 
-    bytes32 _message = keccak256(
-      abi.encode(
-        tokenProxy.PARTIAL_DELEGATION_ON_BEHALF_TYPEHASH(),
-        _delegator,
-        keccak256(abi.encodePacked(_payload)),
-        _suppliedNonce,
-        _deadline
-      )
-    );
+    function testFuzz_RevertIf_DelegatesViaERC712SignatureWithExpiredDeadline(
+        address _actor,
+        uint256 _delegatorPrivateKey,
+        uint256 _delegationSeed,
+        uint256 _delegatorBalance,
+        uint256 _currentNonce,
+        uint256 _currentTimeStamp,
+        uint256 _deadline
+    ) public {
+        vm.assume(_actor != address(0));
+        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+        address _delegator = vm.addr(_delegatorPrivateKey);
+        stdstore
+            .target(address(tokenProxy))
+            .sig("nonces(address)")
+            .with_key(_delegator)
+            .checked_write(_currentNonce);
+        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+        _currentTimeStamp = bound(_currentTimeStamp, 1, type(uint256).max);
+        vm.warp(_currentTimeStamp);
+        _deadline = bound(_deadline, 0, _currentTimeStamp - 1);
 
-    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
-    bytes memory _signature = _sign(_delegatorPrivateKey, _messageHash);
-    vm.prank(_actor);
-    vm.expectRevert(abi.encodeWithSelector(InvalidAccountNonce.selector, _delegator, tokenProxy.nonces(_delegator)));
-    tokenProxy.delegatePartiallyOnBehalf(_delegator, _delegations, _suppliedNonce, _deadline, _signature);
-  }
+        _mint(_delegator, _delegatorBalance);
 
-  function testFuzz_RevertIf_DelegatesViaERC712SignatureWithExpiredDeadline(
-    address _actor,
-    uint256 _delegatorPrivateKey,
-    uint256 _delegationSeed,
-    uint256 _delegatorBalance,
-    uint256 _currentNonce,
-    uint256 _currentTimeStamp,
-    uint256 _deadline
-  ) public {
-    vm.assume(_actor != address(0));
-    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-    address _delegator = vm.addr(_delegatorPrivateKey);
-    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_delegator).checked_write(_currentNonce);
-    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-    _currentTimeStamp = bound(_currentTimeStamp, 1, type(uint256).max);
-    vm.warp(_currentTimeStamp);
-    _deadline = bound(_deadline, 0, _currentTimeStamp - 1);
+        PartialDelegation[] memory _delegations = _createValidPartialDelegation(
+            0,
+            _delegationSeed
+        );
 
-    _mint(_delegator, _delegatorBalance);
+        bytes32[] memory _payload = new bytes32[](_delegations.length);
+        for (uint256 i; i < _delegations.length; i++) {
+            _payload[i] = _hash(_delegations[i]);
+        }
 
-    PartialDelegation[] memory _delegations = _createValidPartialDelegation(0, _delegationSeed);
+        bytes32 _message = keccak256(
+            abi.encode(
+                tokenProxy.PARTIAL_DELEGATION_ON_BEHALF_TYPEHASH(),
+                _delegator,
+                keccak256(abi.encodePacked(_payload)),
+                _currentNonce,
+                _deadline
+            )
+        );
 
-    bytes32[] memory _payload = new bytes32[](_delegations.length);
-    for (uint256 i; i < _delegations.length; i++) {
-      _payload[i] = _hash(_delegations[i]);
+        bytes32 _messageHash = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
+        );
+        bytes memory _signature = _sign(_delegatorPrivateKey, _messageHash);
+        vm.prank(_actor);
+        vm.expectRevert(
+            abi.encodeWithSelector(VotesExpiredSignature.selector, _deadline)
+        );
+        tokenProxy.delegatePartiallyOnBehalf(
+            _delegator,
+            _delegations,
+            _currentNonce,
+            _deadline,
+            _signature
+        );
     }
 
-    bytes32 _message = keccak256(
-      abi.encode(
-        tokenProxy.PARTIAL_DELEGATION_ON_BEHALF_TYPEHASH(),
-        _delegator,
-        keccak256(abi.encodePacked(_payload)),
-        _currentNonce,
-        _deadline
-      )
-    );
+    function testFuzz_RevertIf_DelegatesViaInvalidERC712Signature(
+        address _actor,
+        uint256 _delegatorPrivateKey,
+        uint256 _delegationSeed,
+        uint256 _delegatorBalance,
+        uint256 _currentNonce,
+        uint256 _deadline,
+        uint256 _randomSeed
+    ) public {
+        vm.assume(_actor != address(0));
+        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+        address _delegator = vm.addr(_delegatorPrivateKey);
+        stdstore
+            .target(address(tokenProxy))
+            .sig("nonces(address)")
+            .with_key(_delegator)
+            .checked_write(_currentNonce);
+        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+        _deadline = bound(_deadline, 1, type(uint256).max);
+        vm.warp(_deadline);
+        _deadline = bound(_deadline, 0, block.timestamp - 1);
 
-    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
-    bytes memory _signature = _sign(_delegatorPrivateKey, _messageHash);
-    vm.prank(_actor);
-    vm.expectRevert(abi.encodeWithSelector(VotesExpiredSignature.selector, _deadline));
-    tokenProxy.delegatePartiallyOnBehalf(_delegator, _delegations, _currentNonce, _deadline, _signature);
-  }
+        _mint(_delegator, _delegatorBalance);
 
-  function testFuzz_RevertIf_DelegatesViaInvalidERC712Signature(
-    address _actor,
-    uint256 _delegatorPrivateKey,
-    uint256 _delegationSeed,
-    uint256 _delegatorBalance,
-    uint256 _currentNonce,
-    uint256 _deadline,
-    uint256 _randomSeed
-  ) public {
-    vm.assume(_actor != address(0));
-    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-    address _delegator = vm.addr(_delegatorPrivateKey);
-    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_delegator).checked_write(_currentNonce);
-    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-    _deadline = bound(_deadline, 1, type(uint256).max);
-    vm.warp(_deadline);
-    _deadline = bound(_deadline, 0, block.timestamp - 1);
+        PartialDelegation[] memory _delegations = _createValidPartialDelegation(
+            0,
+            _delegationSeed
+        );
 
-    _mint(_delegator, _delegatorBalance);
+        bytes32[] memory _payload = new bytes32[](_delegations.length);
+        for (uint256 i; i < _delegations.length; i++) {
+            _payload[i] = _hash(_delegations[i]);
+        }
 
-    PartialDelegation[] memory _delegations = _createValidPartialDelegation(0, _delegationSeed);
+        bytes32 _message = keccak256(
+            abi.encode(
+                tokenProxy.PARTIAL_DELEGATION_ON_BEHALF_TYPEHASH(),
+                _delegator,
+                keccak256(abi.encodePacked(_payload)),
+                _currentNonce,
+                _deadline
+            )
+        );
 
-    bytes32[] memory _payload = new bytes32[](_delegations.length);
-    for (uint256 i; i < _delegations.length; i++) {
-      _payload[i] = _hash(_delegations[i]);
+        bytes32 _messageHash = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
+        );
+
+        // Here we use `_randomSeed` as an arbitrary source of randomness to replace a legit parameter
+        // with an attack-like one.
+        if (_randomSeed % 5 == 0) {
+            _delegationSeed = uint256(keccak256(abi.encode(_delegationSeed)));
+        } else if (_randomSeed % 5 == 1) {
+            _delegator = address(
+                uint160(uint256(keccak256(abi.encode(_delegator))))
+            );
+        } else if (_randomSeed % 5 == 2) {
+            _currentNonce = uint256(keccak256(abi.encode(_currentNonce)));
+        } else if (_randomSeed % 5 == 3) {
+            _deadline = uint256(keccak256(abi.encode(_deadline)));
+        }
+
+        bytes memory _signature = _sign(_delegatorPrivateKey, _messageHash);
+        if (_randomSeed % 5 == 4) {
+            _signature = _modifySignature(_signature, _randomSeed);
+        }
+        vm.prank(_actor);
+        vm.expectRevert();
+        tokenProxy.delegatePartiallyOnBehalf(
+            _delegator,
+            _delegations,
+            _currentNonce,
+            _deadline,
+            _signature
+        );
     }
 
-    bytes32 _message = keccak256(
-      abi.encode(
-        tokenProxy.PARTIAL_DELEGATION_ON_BEHALF_TYPEHASH(),
-        _delegator,
-        keccak256(abi.encodePacked(_payload)),
-        _currentNonce,
-        _deadline
-      )
-    );
+    function testFuzz_RevertIf_TheERC1271SignatureIsNotValid(
+        address _actor,
+        uint256 _delegationSeed,
+        uint256 _delegatorBalance,
+        uint256 _currentNonce,
+        uint256 _deadline,
+        bytes memory _signature
+    ) public {
+        vm.assume(_actor != address(0));
+        MockERC1271Signer _erc1271Signer = new MockERC1271Signer();
+        _erc1271Signer.setResponse__isValidSignature(false);
+        address _delegator = address(_erc1271Signer);
+        stdstore
+            .target(address(tokenProxy))
+            .sig("nonces(address)")
+            .with_key(address(_delegator))
+            .checked_write(_currentNonce);
+        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+        _mint(_delegator, _delegatorBalance);
 
-    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
+        PartialDelegation[] memory _delegations = _createValidPartialDelegation(
+            0,
+            _delegationSeed
+        );
 
-    // Here we use `_randomSeed` as an arbitrary source of randomness to replace a legit parameter
-    // with an attack-like one.
-    if (_randomSeed % 5 == 0) {
-      _delegationSeed = uint256(keccak256(abi.encode(_delegationSeed)));
-    } else if (_randomSeed % 5 == 1) {
-      _delegator = address(uint160(uint256(keccak256(abi.encode(_delegator)))));
-    } else if (_randomSeed % 5 == 2) {
-      _currentNonce = uint256(keccak256(abi.encode(_currentNonce)));
-    } else if (_randomSeed % 5 == 3) {
-      _deadline = uint256(keccak256(abi.encode(_deadline)));
+        bytes32[] memory _payload = new bytes32[](_delegations.length);
+        for (uint256 i; i < _delegations.length; i++) {
+            _payload[i] = _hash(_delegations[i]);
+        }
+
+        vm.prank(_actor);
+        vm.expectRevert(InvalidSignature.selector);
+        tokenProxy.delegatePartiallyOnBehalf(
+            _delegator,
+            _delegations,
+            _currentNonce,
+            _deadline,
+            _signature
+        );
     }
 
-    bytes memory _signature = _sign(_delegatorPrivateKey, _messageHash);
-    if (_randomSeed % 5 == 4) {
-      _signature = _modifySignature(_signature, _randomSeed);
+    function _modifySignature(
+        bytes memory _signature,
+        uint256 _index
+    ) internal pure returns (bytes memory) {
+        _index = bound(_index, 0, _signature.length - 1);
+        // zero out the byte at the given index, or set it to 1 if it's already zero
+        if (_signature[_index] == 0) {
+            _signature[_index] = bytes1(uint8(1));
+        } else {
+            _signature[_index] = bytes1(uint8(0));
+        }
+        return _signature;
     }
-    vm.prank(_actor);
-    vm.expectRevert();
-    tokenProxy.delegatePartiallyOnBehalf(_delegator, _delegations, _currentNonce, _deadline, _signature);
-  }
-
-  function testFuzz_RevertIf_TheERC1271SignatureIsNotValid(
-    address _actor,
-    uint256 _delegationSeed,
-    uint256 _delegatorBalance,
-    uint256 _currentNonce,
-    uint256 _deadline,
-    bytes memory _signature
-  ) public {
-    vm.assume(_actor != address(0));
-    MockERC1271Signer _erc1271Signer = new MockERC1271Signer();
-    _erc1271Signer.setResponse__isValidSignature(false);
-    address _delegator = address(_erc1271Signer);
-    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(address(_delegator)).checked_write(
-      _currentNonce
-    );
-    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-    _mint(_delegator, _delegatorBalance);
-
-    PartialDelegation[] memory _delegations = _createValidPartialDelegation(0, _delegationSeed);
-
-    bytes32[] memory _payload = new bytes32[](_delegations.length);
-    for (uint256 i; i < _delegations.length; i++) {
-      _payload[i] = _hash(_delegations[i]);
-    }
-
-    vm.prank(_actor);
-    vm.expectRevert(InvalidSignature.selector);
-    tokenProxy.delegatePartiallyOnBehalf(_delegator, _delegations, _currentNonce, _deadline, _signature);
-  }
-
-  function _modifySignature(bytes memory _signature, uint256 _index) internal pure returns (bytes memory) {
-    _index = bound(_index, 0, _signature.length - 1);
-    // zero out the byte at the given index, or set it to 1 if it's already zero
-    if (_signature[_index] == 0) {
-      _signature[_index] = bytes1(uint8(1));
-    } else {
-      _signature[_index] = bytes1(uint8(0));
-    }
-    return _signature;
-  }
 }
 
 contract InvalidateNonce is PartialDelegationTest {
-  using stdStorage for StdStorage;
+    using stdStorage for StdStorage;
 
-  function testFuzz_SucessfullyIncrementsTheNonceOfTheSender(address _caller, uint256 _initialNonce) public {
-    vm.assume(_caller != address(0));
-    vm.assume(_initialNonce != type(uint256).max);
+    function testFuzz_SucessfullyIncrementsTheNonceOfTheSender(
+        address _caller,
+        uint256 _initialNonce
+    ) public {
+        vm.assume(_caller != address(0));
+        vm.assume(_initialNonce != type(uint256).max);
 
-    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_caller).checked_write(_initialNonce);
+        stdstore
+            .target(address(tokenProxy))
+            .sig("nonces(address)")
+            .with_key(_caller)
+            .checked_write(_initialNonce);
 
-    vm.prank(_caller);
-    tokenProxy.invalidateNonce();
+        vm.prank(_caller);
+        tokenProxy.invalidateNonce();
 
-    uint256 currentNonce = tokenProxy.nonces(_caller);
+        uint256 currentNonce = tokenProxy.nonces(_caller);
 
-    assertEq(currentNonce, _initialNonce + 1, "Current nonce is incorrect");
-  }
+        assertEq(currentNonce, _initialNonce + 1, "Current nonce is incorrect");
+    }
 
-  function testFuzz_IncreasesTheNonceByTwoWhenCalledTwice(address _caller, uint256 _initialNonce) public {
-    vm.assume(_caller != address(0));
-    _initialNonce = bound(_initialNonce, 0, type(uint256).max - 2);
+    function testFuzz_IncreasesTheNonceByTwoWhenCalledTwice(
+        address _caller,
+        uint256 _initialNonce
+    ) public {
+        vm.assume(_caller != address(0));
+        _initialNonce = bound(_initialNonce, 0, type(uint256).max - 2);
 
-    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_caller).checked_write(_initialNonce);
+        stdstore
+            .target(address(tokenProxy))
+            .sig("nonces(address)")
+            .with_key(_caller)
+            .checked_write(_initialNonce);
 
-    vm.prank(_caller);
-    tokenProxy.invalidateNonce();
+        vm.prank(_caller);
+        tokenProxy.invalidateNonce();
 
-    vm.prank(_caller);
-    tokenProxy.invalidateNonce();
+        vm.prank(_caller);
+        tokenProxy.invalidateNonce();
 
-    uint256 currentNonce = tokenProxy.nonces(_caller);
+        uint256 currentNonce = tokenProxy.nonces(_caller);
 
-    assertEq(currentNonce, _initialNonce + 2, "Current nonce is incorrect");
-  }
+        assertEq(currentNonce, _initialNonce + 2, "Current nonce is incorrect");
+    }
 }
 
 contract Transfer is PartialDelegationTest {
-  function testFuzz_MovesVotesFromOneDelegateeSetToAnother(
-    address _from,
-    address _to,
-    uint256 _amount,
-    uint256 _toExistingBalance
-  ) public {
-    vm.assume(_from != address(0));
-    vm.assume(_to != address(0));
-    vm.assume(_from != _to);
-    _amount = bound(_amount, 0, type(uint208).max);
-    _toExistingBalance = bound(_toExistingBalance, 0, type(uint208).max - _amount);
-    PartialDelegation[] memory _fromDelegations =
-      _createValidPartialDelegation(0, uint256(keccak256(abi.encode(_from))));
-    PartialDelegation[] memory _toDelegations = _createValidPartialDelegation(0, uint256(keccak256(abi.encode(_to))));
-    vm.startPrank(_to);
-    tokenProxy.mint(_toExistingBalance);
-    tokenProxy.delegate(_toDelegations);
-    vm.stopPrank();
-    vm.startPrank(_from);
-    tokenProxy.mint(_amount);
-    tokenProxy.delegate(_fromDelegations);
-    tokenProxy.transfer(_to, _amount);
-    vm.stopPrank();
+    function testFuzz_MovesVotesFromOneDelegateeSetToAnother(
+        address _from,
+        address _to,
+        uint256 _amount,
+        uint256 _toExistingBalance
+    ) public {
+        vm.assume(_from != address(0));
+        vm.assume(_to != address(0));
+        vm.assume(_from != _to);
+        _amount = bound(_amount, 0, type(uint208).max);
+        _toExistingBalance = bound(
+            _toExistingBalance,
+            0,
+            type(uint208).max - _amount
+        );
+        PartialDelegation[]
+            memory _fromDelegations = _createValidPartialDelegation(
+                0,
+                uint256(keccak256(abi.encode(_from)))
+            );
+        PartialDelegation[]
+            memory _toDelegations = _createValidPartialDelegation(
+                0,
+                uint256(keccak256(abi.encode(_to)))
+            );
+        vm.startPrank(_to);
+        tokenProxy.mint(_toExistingBalance);
+        tokenProxy.delegate(_toDelegations);
+        vm.stopPrank();
+        vm.startPrank(_from);
+        tokenProxy.mint(_amount);
+        tokenProxy.delegate(_fromDelegations);
+        tokenProxy.transfer(_to, _amount);
+        vm.stopPrank();
 
-    // check that voting power has been reduced on `from` side by proper amount
-    uint256 _fromTotal = 0;
-    for (uint256 i = 0; i < _fromDelegations.length; i++) {
-      assertEq(tokenProxy.getVotes(_fromDelegations[i]._delegatee), 0);
-      _fromTotal += tokenProxy.getVotes(_fromDelegations[i]._delegatee);
+        // check that voting power has been reduced on `from` side by proper amount
+        uint256 _fromTotal = 0;
+        for (uint256 i = 0; i < _fromDelegations.length; i++) {
+            assertEq(tokenProxy.getVotes(_fromDelegations[i]._delegatee), 0);
+            _fromTotal += tokenProxy.getVotes(_fromDelegations[i]._delegatee);
+        }
+        assertEq(_fromTotal, 0, "`from` address total votes mismatch");
+        // check that voting power has been augmented on `to` side by proper amount
+        assertCorrectVotes(_toDelegations, _toExistingBalance + _amount);
+        // check that the asset balance successfully updated
+        assertEq(tokenProxy.balanceOf(_from), 0, "nonzero `from` balance");
+        assertEq(
+            tokenProxy.balanceOf(_to),
+            _toExistingBalance + _amount,
+            "`to` balance mismatch"
+        );
+        assertEq(
+            tokenProxy.totalSupply(),
+            _toExistingBalance + _amount,
+            "total supply mismatch"
+        );
     }
-    assertEq(_fromTotal, 0, "`from` address total votes mismatch");
-    // check that voting power has been augmented on `to` side by proper amount
-    assertCorrectVotes(_toDelegations, _toExistingBalance + _amount);
-    // check that the asset balance successfully updated
-    assertEq(tokenProxy.balanceOf(_from), 0, "nonzero `from` balance");
-    assertEq(tokenProxy.balanceOf(_to), _toExistingBalance + _amount, "`to` balance mismatch");
-    assertEq(tokenProxy.totalSupply(), _toExistingBalance + _amount, "total supply mismatch");
-  }
 
-  function testFuzz_EmitsDelegateVotesChangedEventsWhenVotesMoveFromOneDelegateeSetToAnother(
-    address _from,
-    address _to,
-    uint256 _amount,
-    uint256 _toExistingBalance
-  ) public {
-    vm.assume(_from != address(0));
-    vm.assume(_to != address(0));
-    vm.assume(_from != _to);
-    _amount = bound(_amount, 1, type(uint208).max);
-    _toExistingBalance = bound(_toExistingBalance, 0, type(uint208).max - _amount);
-    PartialDelegation[] memory _fromDelegations =
-      _createValidPartialDelegation(0, uint256(keccak256(abi.encode(_from))));
-    PartialDelegation[] memory _toDelegations = _createValidPartialDelegation(0, uint256(keccak256(abi.encode(_to))));
-    vm.startPrank(_to);
-    tokenProxy.mint(_toExistingBalance);
-    tokenProxy.delegate(_toDelegations);
-    vm.stopPrank();
-    vm.startPrank(_from);
-    tokenProxy.mint(_amount);
-    tokenProxy.delegate(_fromDelegations);
+    function testFuzz_EmitsDelegateVotesChangedEventsWhenVotesMoveFromOneDelegateeSetToAnother(
+        address _from,
+        address _to,
+        uint256 _amount,
+        uint256 _toExistingBalance
+    ) public {
+        vm.assume(_from != address(0));
+        vm.assume(_to != address(0));
+        vm.assume(_from != _to);
+        _amount = bound(_amount, 1, type(uint208).max);
+        _toExistingBalance = bound(
+            _toExistingBalance,
+            0,
+            type(uint208).max - _amount
+        );
+        PartialDelegation[]
+            memory _fromDelegations = _createValidPartialDelegation(
+                0,
+                uint256(keccak256(abi.encode(_from)))
+            );
+        PartialDelegation[]
+            memory _toDelegations = _createValidPartialDelegation(
+                0,
+                uint256(keccak256(abi.encode(_to)))
+            );
+        vm.startPrank(_to);
+        tokenProxy.mint(_toExistingBalance);
+        tokenProxy.delegate(_toDelegations);
+        vm.stopPrank();
+        vm.startPrank(_from);
+        tokenProxy.mint(_amount);
+        tokenProxy.delegate(_fromDelegations);
 
-    _expectEmitDelegateVotesChangedEvents(_amount, _toExistingBalance, _fromDelegations, _toDelegations);
-    tokenProxy.transfer(_to, _amount);
-    vm.stopPrank();
-  }
+        _expectEmitDelegateVotesChangedEvents(
+            _amount,
+            _toExistingBalance,
+            _fromDelegations,
+            _toDelegations
+        );
+        tokenProxy.transfer(_to, _amount);
+        vm.stopPrank();
+    }
 
-  function testFuzz_HandlesTransfersToSelf(address _holder, uint256 _transferAmount, uint256 _existingBalance) public {
-    vm.assume(_holder != address(0));
-    _transferAmount = bound(_transferAmount, 0, type(uint208).max);
-    _existingBalance = bound(_existingBalance, _transferAmount, type(uint208).max);
-    PartialDelegation[] memory _delegations = _createValidPartialDelegation(0, uint256(keccak256(abi.encode(_holder))));
-    vm.startPrank(_holder);
-    tokenProxy.mint(_existingBalance);
-    tokenProxy.delegate(_delegations);
-    tokenProxy.transfer(_holder, _transferAmount);
-    vm.stopPrank();
-    assertCorrectVotes(_delegations, _existingBalance);
-    assertEq(tokenProxy.balanceOf(_holder), _existingBalance, "holder balance is wrong");
-    assertEq(tokenProxy.totalSupply(), _existingBalance, "total supply mismatch");
-  }
+    function testFuzz_HandlesTransfersToSelf(
+        address _holder,
+        uint256 _transferAmount,
+        uint256 _existingBalance
+    ) public {
+        vm.assume(_holder != address(0));
+        _transferAmount = bound(_transferAmount, 0, type(uint208).max);
+        _existingBalance = bound(
+            _existingBalance,
+            _transferAmount,
+            type(uint208).max
+        );
+        PartialDelegation[] memory _delegations = _createValidPartialDelegation(
+            0,
+            uint256(keccak256(abi.encode(_holder)))
+        );
+        vm.startPrank(_holder);
+        tokenProxy.mint(_existingBalance);
+        tokenProxy.delegate(_delegations);
+        tokenProxy.transfer(_holder, _transferAmount);
+        vm.stopPrank();
+        assertCorrectVotes(_delegations, _existingBalance);
+        assertEq(
+            tokenProxy.balanceOf(_holder),
+            _existingBalance,
+            "holder balance is wrong"
+        );
+        assertEq(
+            tokenProxy.totalSupply(),
+            _existingBalance,
+            "total supply mismatch"
+        );
+    }
 }
 
 contract Permit is PartialDelegationTest {
-  error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);
-  error ERC2612ExpiredSignature(uint256 deadline);
-  error ERC2612InvalidSigner(address signer, address owner);
-
-  function testFuzz_SuccessfullySetsAllowance(
-    uint256 _holderSeed,
-    address _receiver,
-    uint256 _transferAmount,
-    uint256 _existingBalance,
-    uint256 _deadline
-  ) public {
-    _holderSeed = bound(
-      _holderSeed,
-      1,
-      /* private key can't be bigger than secp256k1 curve order */
-      115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 - 1
+    error ERC20InsufficientAllowance(
+        address spender,
+        uint256 allowance,
+        uint256 needed
     );
-    address _holder = vm.addr(_holderSeed);
-    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-    vm.assume(_holder != address(0));
-    vm.assume(_receiver != address(0) && _receiver != _holder);
-    _transferAmount = bound(_transferAmount, 0, type(uint208).max);
-    _existingBalance = bound(_existingBalance, _transferAmount, type(uint208).max);
+    error ERC2612ExpiredSignature(uint256 deadline);
+    error ERC2612InvalidSigner(address signer, address owner);
 
-    vm.startPrank(_holder);
-    tokenProxy.mint(_existingBalance);
-    bytes32 _message = keccak256(
-      abi.encode(
-        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"),
-        _holder,
-        _receiver,
-        _transferAmount,
-        tokenProxy.nonces(_holder),
-        _deadline
-      )
-    );
-    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
-    (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_holderSeed, _messageHash);
+    function testFuzz_SuccessfullySetsAllowance(
+        uint256 _holderSeed,
+        address _receiver,
+        uint256 _transferAmount,
+        uint256 _existingBalance,
+        uint256 _deadline
+    ) public {
+        _holderSeed = bound(
+            _holderSeed,
+            1,
+            /* private key can't be bigger than secp256k1 curve order */
+            115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 -
+                1
+        );
+        address _holder = vm.addr(_holderSeed);
+        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+        vm.assume(_holder != address(0));
+        vm.assume(_receiver != address(0) && _receiver != _holder);
+        _transferAmount = bound(_transferAmount, 0, type(uint208).max);
+        _existingBalance = bound(
+            _existingBalance,
+            _transferAmount,
+            type(uint208).max
+        );
 
-    tokenProxy.permit(_holder, _receiver, _transferAmount, _deadline, _v, _r, _s);
-    vm.stopPrank();
+        vm.startPrank(_holder);
+        tokenProxy.mint(_existingBalance);
+        bytes32 _message = keccak256(
+            abi.encode(
+                keccak256(
+                    "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
+                ),
+                _holder,
+                _receiver,
+                _transferAmount,
+                tokenProxy.nonces(_holder),
+                _deadline
+            )
+        );
+        bytes32 _messageHash = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
+        );
+        (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_holderSeed, _messageHash);
 
-    assertEq(tokenProxy.allowance(_holder, _receiver), _transferAmount);
-    vm.prank(_receiver);
-    tokenProxy.transferFrom(_holder, _receiver, _transferAmount);
-    assertEq(tokenProxy.balanceOf(_receiver), _transferAmount);
-  }
+        tokenProxy.permit(
+            _holder,
+            _receiver,
+            _transferAmount,
+            _deadline,
+            _v,
+            _r,
+            _s
+        );
+        vm.stopPrank();
 
-  function testFuzz_RevertIf_ERC2612ExpiredSignature(
-    uint256 _holderSeed,
-    address _receiver,
-    uint256 _transferAmount,
-    uint256 _existingBalance,
-    uint256 _invalidDeadline
-  ) public {
-    _holderSeed = bound(
-      _holderSeed,
-      1,
-      /* private key can't be bigger than secp256k1 curve order */
-      115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 - 1
-    );
-    address _holder = vm.addr(_holderSeed);
-    _invalidDeadline = bound(_invalidDeadline, 0, block.timestamp - 1);
-    vm.assume(_holder != address(0));
-    vm.assume(_receiver != address(0) && _receiver != _holder);
-    _transferAmount = bound(_transferAmount, 0, type(uint208).max);
-    _existingBalance = bound(_existingBalance, _transferAmount, type(uint208).max);
-
-    vm.startPrank(_holder);
-    tokenProxy.mint(_existingBalance);
-    bytes32 _message = keccak256(
-      abi.encode(
-        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"),
-        _holder,
-        _receiver,
-        _transferAmount,
-        tokenProxy.nonces(_holder),
-        _invalidDeadline
-      )
-    );
-    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
-    (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_holderSeed, _messageHash);
-
-    vm.expectRevert(abi.encodeWithSelector(ERC2612ExpiredSignature.selector, _invalidDeadline));
-    tokenProxy.permit(_holder, _receiver, _transferAmount, _invalidDeadline, _v, _r, _s);
-    vm.stopPrank();
-  }
-
-  function testFuzz_RevertIf_ERC2612InvalidSigner(
-    uint256 _holderSeed,
-    address _receiver,
-    uint256 _transferAmount,
-    uint256 _existingBalance,
-    uint256 _deadline,
-    uint256 _randomSeed
-  ) public {
-    _holderSeed = bound(
-      _holderSeed,
-      1,
-      /* private key can't be bigger than secp256k1 curve order */
-      115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 - 1
-    );
-    address _holder = vm.addr(_holderSeed);
-    _deadline = bound(_deadline, 0, block.timestamp - 1);
-    vm.assume(_holder != address(0));
-    vm.assume(_receiver != address(0) && _receiver != _holder);
-    _transferAmount = bound(_transferAmount, 0, type(uint208).max);
-    _existingBalance = bound(_existingBalance, _transferAmount, type(uint208).max);
-
-    vm.startPrank(_holder);
-    tokenProxy.mint(_existingBalance);
-    bytes32 _message = keccak256(
-      abi.encode(
-        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"),
-        _holder,
-        _receiver,
-        _transferAmount,
-        tokenProxy.nonces(_holder),
-        _deadline
-      )
-    );
-    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
-
-    // Here we use `_randomSeed` as an arbitrary source of randomness to replace a legit parameter
-    // with an attack-like one.
-    if (_randomSeed % 3 == 0) {
-      _receiver = address(uint160(uint256(keccak256(abi.encode(_receiver)))));
-    } else if (_randomSeed % 3 == 1) {
-      _transferAmount = uint256(keccak256(abi.encode(_transferAmount)));
-    }
-    (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_holderSeed, _messageHash);
-    if (_randomSeed % 3 == 2) {
-      (_v, _r, _s) = vm.sign(uint256(keccak256(abi.encode(_holderSeed))), _messageHash);
+        assertEq(tokenProxy.allowance(_holder, _receiver), _transferAmount);
+        vm.prank(_receiver);
+        tokenProxy.transferFrom(_holder, _receiver, _transferAmount);
+        assertEq(tokenProxy.balanceOf(_receiver), _transferAmount);
     }
 
-    vm.expectRevert(abi.encodeWithSelector(ERC2612ExpiredSignature.selector, _deadline));
-    tokenProxy.permit(_holder, _receiver, _transferAmount, _deadline, _v, _r, _s);
-    vm.stopPrank();
-  }
+    function testFuzz_RevertIf_ERC2612ExpiredSignature(
+        uint256 _holderSeed,
+        address _receiver,
+        uint256 _transferAmount,
+        uint256 _existingBalance,
+        uint256 _invalidDeadline
+    ) public {
+        _holderSeed = bound(
+            _holderSeed,
+            1,
+            /* private key can't be bigger than secp256k1 curve order */
+            115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 -
+                1
+        );
+        address _holder = vm.addr(_holderSeed);
+        _invalidDeadline = bound(_invalidDeadline, 0, block.timestamp - 1);
+        vm.assume(_holder != address(0));
+        vm.assume(_receiver != address(0) && _receiver != _holder);
+        _transferAmount = bound(_transferAmount, 0, type(uint208).max);
+        _existingBalance = bound(
+            _existingBalance,
+            _transferAmount,
+            type(uint208).max
+        );
+
+        vm.startPrank(_holder);
+        tokenProxy.mint(_existingBalance);
+        bytes32 _message = keccak256(
+            abi.encode(
+                keccak256(
+                    "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
+                ),
+                _holder,
+                _receiver,
+                _transferAmount,
+                tokenProxy.nonces(_holder),
+                _invalidDeadline
+            )
+        );
+        bytes32 _messageHash = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
+        );
+        (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_holderSeed, _messageHash);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ERC2612ExpiredSignature.selector,
+                _invalidDeadline
+            )
+        );
+        tokenProxy.permit(
+            _holder,
+            _receiver,
+            _transferAmount,
+            _invalidDeadline,
+            _v,
+            _r,
+            _s
+        );
+        vm.stopPrank();
+    }
+
+    function testFuzz_RevertIf_ERC2612InvalidSigner(
+        uint256 _holderSeed,
+        address _receiver,
+        uint256 _transferAmount,
+        uint256 _existingBalance,
+        uint256 _deadline,
+        uint256 _randomSeed
+    ) public {
+        _holderSeed = bound(
+            _holderSeed,
+            1,
+            /* private key can't be bigger than secp256k1 curve order */
+            115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 -
+                1
+        );
+        address _holder = vm.addr(_holderSeed);
+        _deadline = bound(_deadline, 0, block.timestamp - 1);
+        vm.assume(_holder != address(0));
+        vm.assume(_receiver != address(0) && _receiver != _holder);
+        _transferAmount = bound(_transferAmount, 0, type(uint208).max);
+        _existingBalance = bound(
+            _existingBalance,
+            _transferAmount,
+            type(uint208).max
+        );
+
+        vm.startPrank(_holder);
+        tokenProxy.mint(_existingBalance);
+        bytes32 _message = keccak256(
+            abi.encode(
+                keccak256(
+                    "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
+                ),
+                _holder,
+                _receiver,
+                _transferAmount,
+                tokenProxy.nonces(_holder),
+                _deadline
+            )
+        );
+        bytes32 _messageHash = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
+        );
+
+        // Here we use `_randomSeed` as an arbitrary source of randomness to replace a legit parameter
+        // with an attack-like one.
+        if (_randomSeed % 3 == 0) {
+            _receiver = address(
+                uint160(uint256(keccak256(abi.encode(_receiver))))
+            );
+        } else if (_randomSeed % 3 == 1) {
+            _transferAmount = uint256(keccak256(abi.encode(_transferAmount)));
+        }
+        (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_holderSeed, _messageHash);
+        if (_randomSeed % 3 == 2) {
+            (_v, _r, _s) = vm.sign(
+                uint256(keccak256(abi.encode(_holderSeed))),
+                _messageHash
+            );
+        }
+
+        vm.expectRevert(
+            abi.encodeWithSelector(ERC2612ExpiredSignature.selector, _deadline)
+        );
+        tokenProxy.permit(
+            _holder,
+            _receiver,
+            _transferAmount,
+            _deadline,
+            _v,
+            _r,
+            _s
+        );
+        vm.stopPrank();
+    }
 }
 
 contract GetPastVotes is PartialDelegationTest {
-  function testFuzz_ReturnsCorrectVotes(address _actor, uint256 _amount, uint48 _blocksAhead, uint256 _secondMint)
-    public
-  {
-    vm.assume(_actor != address(0));
-    _amount = bound(_amount, 0, type(uint208).max);
-    _secondMint = bound(_secondMint, 0, type(uint208).max - _amount);
-    uint256 _blockNo = vm.getBlockNumber();
-    _blocksAhead = uint48(bound(_blocksAhead, 1, type(uint48).max - _blockNo));
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-    vm.stopPrank();
-    PartialDelegation[] memory _delegations = _createValidPartialDelegation(0, uint256(keccak256(abi.encode(_actor))));
-    vm.startPrank(_actor);
-    tokenProxy.delegate(_delegations);
-    vm.stopPrank();
-    vm.roll(_blockNo + _blocksAhead);
-    vm.startPrank(_actor);
-    // do a second mint that will increase delegatees' votes
-    tokenProxy.mint(_secondMint);
-    vm.stopPrank();
-    assertCorrectPastVotes(_delegations, _amount, _blockNo);
-    assertCorrectVotes(_delegations, _amount + _secondMint);
-  }
+    function testFuzz_ReturnsCorrectVotes(
+        address _actor,
+        uint256 _amount,
+        uint48 _blocksAhead,
+        uint256 _secondMint
+    ) public {
+        vm.assume(_actor != address(0));
+        _amount = bound(_amount, 0, type(uint208).max);
+        _secondMint = bound(_secondMint, 0, type(uint208).max - _amount);
+        uint256 _blockNo = vm.getBlockNumber();
+        _blocksAhead = uint48(
+            bound(_blocksAhead, 1, type(uint48).max - _blockNo)
+        );
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+        vm.stopPrank();
+        PartialDelegation[] memory _delegations = _createValidPartialDelegation(
+            0,
+            uint256(keccak256(abi.encode(_actor)))
+        );
+        vm.startPrank(_actor);
+        tokenProxy.delegate(_delegations);
+        vm.stopPrank();
+        vm.roll(_blockNo + _blocksAhead);
+        vm.startPrank(_actor);
+        // do a second mint that will increase delegatees' votes
+        tokenProxy.mint(_secondMint);
+        vm.stopPrank();
+        assertCorrectPastVotes(_delegations, _amount, _blockNo);
+        assertCorrectVotes(_delegations, _amount + _secondMint);
+    }
 }
 
 contract GetPastTotalSupply is PartialDelegationTest {
-  function testFuzz_ReturnsCorrectPastTotalSupply(
-    address _actor,
-    uint256 _amount,
-    uint48 _blocksAhead,
-    uint256 _secondMint
-  ) public {
-    vm.assume(_actor != address(0));
-    _amount = bound(_amount, 0, type(uint208).max);
-    _secondMint = bound(_secondMint, 0, type(uint208).max - _amount);
-    uint256 _blockNo = vm.getBlockNumber();
-    _blocksAhead = uint48(bound(_blocksAhead, 1, type(uint48).max - _blockNo));
-    vm.startPrank(_actor);
-    tokenProxy.mint(_amount);
-    vm.roll(_blockNo + _blocksAhead);
-    // do a second mint that will increase total supply
-    tokenProxy.mint(_secondMint);
-    vm.stopPrank();
-    assertEq(tokenProxy.totalSupply(), _amount + _secondMint);
-    assertEq(tokenProxy.getPastTotalSupply(_blockNo), _amount);
-  }
+    function testFuzz_ReturnsCorrectPastTotalSupply(
+        address _actor,
+        uint256 _amount,
+        uint48 _blocksAhead,
+        uint256 _secondMint
+    ) public {
+        vm.assume(_actor != address(0));
+        _amount = bound(_amount, 0, type(uint208).max);
+        _secondMint = bound(_secondMint, 0, type(uint208).max - _amount);
+        uint256 _blockNo = vm.getBlockNumber();
+        _blocksAhead = uint48(
+            bound(_blocksAhead, 1, type(uint48).max - _blockNo)
+        );
+        vm.startPrank(_actor);
+        tokenProxy.mint(_amount);
+        vm.roll(_blockNo + _blocksAhead);
+        // do a second mint that will increase total supply
+        tokenProxy.mint(_secondMint);
+        vm.stopPrank();
+        assertEq(tokenProxy.totalSupply(), _amount + _secondMint);
+        assertEq(tokenProxy.getPastTotalSupply(_blockNo), _amount);
+    }
+}
+
+contract VoteableSupplyTest is PartialDelegationTest {
+
+  function testFuzz_VoteableSupplyMatchesSumOfDelegations(
+        address _delegator,
+        uint256 _amount,
+        address[5] memory _delegatees,
+        uint256[5] memory _delegationAmounts
+    ) public {
+        vm.assume(_delegator != address(0));
+        for (uint256 i = 0; i < 5; i++) {
+            vm.assume(_delegatees[i] != address(0));
+            vm.assume(_delegatees[i] != _delegator);
+            for (uint256 j = 0; j < i; j++) {
+                vm.assume(_delegatees[i] != _delegatees[j]);
+            }
+        }
+
+        _amount = bound(_amount, 1000, type(uint208).max);
+        
+        vm.startPrank(_delegator);
+        tokenProxy.mint(_amount);
+
+        PartialDelegation[] memory delegations = new PartialDelegation[](5);
+        uint256 totalDelegated = 0;
+
+        for (uint256 i = 0; i < 5; i++) {
+            _delegationAmounts[i] = bound(_delegationAmounts[i], 1, _amount / 5);
+            totalDelegated += _delegationAmounts[i];
+            delegations[i] = PartialDelegation({
+                _delegatee: _delegatees[i],
+                _numerator: (_delegationAmounts[i] * tokenProxy.DENOMINATOR()) / _amount
+            });
+        }
+
+        // Ensure total delegated amount doesn't exceed _amount
+        if (totalDelegated > _amount) {
+            uint256 excess = totalDelegated - _amount;
+            for (uint256 i = 0; i < 5 && excess > 0; i++) {
+                if (_delegationAmounts[i] > excess) {
+                    _delegationAmounts[i] -= excess;
+                    totalDelegated -= excess;
+                    excess = 0;
+                } else {
+                    totalDelegated -= _delegationAmounts[i];
+                    excess -= _delegationAmounts[i];
+                    _delegationAmounts[i] = 0;
+                }
+                delegations[i]._numerator = (_delegationAmounts[i] * tokenProxy.DENOMINATOR()) / _amount;
+            }
+        }
+
+        tokenProxy.delegate(delegations);
+        vm.stopPrank();
+
+        uint256 voteableSupply = tokenProxy.getVoteableSupply();
+        uint256 sumOfDelegations = 0;
+
+        for (uint256 i = 0; i < 5; i++) {
+            sumOfDelegations += tokenProxy.getVotes(_delegatees[i]);
+        }
+
+        assertEq(voteableSupply, sumOfDelegations, "Voteable supply should match sum of delegations");
+        assertLe(voteableSupply, _amount, "Voteable supply should not exceed total minted amount");
+    }
+    function testFuzz_VoteableSupplyAfterPartialDelegations(
+        address[5] memory _actors,
+        uint256[5] memory _amounts,
+        uint256[5] memory _seeds
+    ) public {
+        uint256 totalSupply = 0;
+        uint256 expectedVoteableSupply = 0;
+        uint256 totalDelegations = 0;
+
+        for (uint256 i = 0; i < _actors.length; i++) {
+            vm.assume(_actors[i] != address(0));
+            _amounts[i] = bound(_amounts[i], 0, type(uint208).max / _actors.length);
+
+            vm.startPrank(_actors[i]);
+            tokenProxy.mint(_amounts[i]);
+            totalSupply += _amounts[i];
+
+            PartialDelegation[] memory delegations = _createValidPartialDelegation(
+                0,
+                uint256(keccak256(abi.encode(_seeds[i])))
+            );
+            tokenProxy.delegate(delegations);
+            totalDelegations += delegations.length;
+
+            vm.stopPrank();
+        }
+
+        assertLe(
+            tokenProxy.getVoteableSupply(),
+            tokenProxy.totalSupply(),
+            "Voteable supply exceeds total supply"
+        );
+
+        // Additional assertions
+        assertEq(
+            tokenProxy.totalSupply(),
+            totalSupply,
+            "Incorrect total supply"
+        );
+        assertLt(
+            tokenProxy.getVoteableSupply(),
+            totalSupply,
+            "Voteable supply should be less than total supply"
+        );
+    }
+
+    function testFuzz_VoteableSupplyAfterTransfers(
+        address[3] memory _actors,
+        uint256[3] memory _amounts,
+        uint256[3] memory _seeds,
+        uint256 _transferAmount
+    ) public {
+        vm.assume(_actors[0] != address(0) && _actors[1] != address(0) && _actors[2] != address(0));
+        vm.assume(_actors[0] != _actors[1] && _actors[1] != _actors[2] && _actors[0] != _actors[2]);
+
+        uint256 expectedVoteableSupply = 0;
+        uint256 totalSupply = 0;
+
+        for (uint256 i = 0; i < 3; i++) {
+            _amounts[i] = bound(_amounts[i], 100, type(uint208).max / 3);
+            totalSupply += _amounts[i];
+
+            vm.startPrank(_actors[i]);
+            tokenProxy.mint(_amounts[i]);
+
+            PartialDelegation[] memory delegations = _createValidPartialDelegation(
+                0,
+                _seeds[i]
+            );
+            tokenProxy.delegate(delegations);
+
+            vm.stopPrank();
+        }
+
+        assertEq(
+            tokenProxy.getVoteableSupply(),
+            expectedVoteableSupply,
+            "Initial voteable supply is incorrect"
+        );
+        assertLe(
+            tokenProxy.getVoteableSupply(),
+            totalSupply,
+            "Voteable supply should not exceed total supply"
+        );
+
+        _transferAmount = bound(_transferAmount, 1, _amounts[0]);
+
+        vm.prank(_actors[0]);
+        tokenProxy.transfer(_actors[1], _transferAmount);
+
+        uint256 newVoteableSupply = tokenProxy.getVoteableSupply();
+
+        assertEq(
+            tokenProxy.totalSupply(),
+            totalSupply,
+            "Total supply should not change after transfer"
+        );
+        assertLe(
+            newVoteableSupply,
+            totalSupply,
+            "Voteable supply should not exceed total supply after transfer"
+        );
+        assertEq(
+            newVoteableSupply,
+            expectedVoteableSupply,
+            "Voteable supply should not change after transfer if delegations remain the same"
+        );
+    }
 }
 
 // This contract strengthens our confidence in our test helper, `_expectEmitDelegateVotesChangedEvents`
 contract ExpectEmitDelegateVotesChangedEvents is PartialDelegationTest {
-  /// An Ethereum log. Returned by `getRecordedLogs`.
+    /// An Ethereum log. Returned by `getRecordedLogs`.
 
-  function test_EmitsWhenFromNoDelegateeToANewDelegateeIsAdded() public {
-    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](0);
-    PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
-    _newDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 10_000});
+    function test_EmitsWhenFromNoDelegateeToANewDelegateeIsAdded() public {
+        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](0);
+        PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
+        _newDelegations[0] = PartialDelegation({
+            _delegatee: address(0x1),
+            _numerator: 10_000
+        });
 
-    vm.recordLogs();
-    _expectEmitDelegateVotesChangedEvents(100, _oldDelegations, _newDelegations);
-    Vm.Log[] memory entries = vm.getRecordedLogs();
-    uint256 _logLength = entries.length;
+        vm.recordLogs();
+        _expectEmitDelegateVotesChangedEvents(
+            100,
+            _oldDelegations,
+            _newDelegations
+        );
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        uint256 _logLength = entries.length;
 
-    // Initialized(18_446_744_073_709_551_615) from FakeERC20VotesPartialDelegationUpgradeable utils = new
-    // FakeERC20VotesPartialDelegationUpgradeable();
-    assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
-    emit DelegateVotesChanged(address(0x1), 0, 100);
-    assertEq(_logLength, 2);
-  }
+        // Initialized(18_446_744_073_709_551_615) from FakeERC20VotesPartialDelegationUpgradeable utils = new
+        // FakeERC20VotesPartialDelegationUpgradeable();
+        assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
+        emit DelegateVotesChanged(address(0x1), 0, 100);
+        assertEq(_logLength, 2);
+    }
 
-  function test_EmitsWhenBothDelegationsHaveTheSameDelegatee() public {
-    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
-    _oldDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 10_000});
-    PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
-    _newDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 10_000});
+    function test_EmitsWhenBothDelegationsHaveTheSameDelegatee() public {
+        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
+        _oldDelegations[0] = PartialDelegation({
+            _delegatee: address(0x1),
+            _numerator: 10_000
+        });
+        PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
+        _newDelegations[0] = PartialDelegation({
+            _delegatee: address(0x1),
+            _numerator: 10_000
+        });
 
-    vm.recordLogs();
-    _expectEmitDelegateVotesChangedEvents(100, _oldDelegations, _newDelegations);
-    Vm.Log[] memory entries = vm.getRecordedLogs();
-    uint256 _logLength = entries.length;
+        vm.recordLogs();
+        _expectEmitDelegateVotesChangedEvents(
+            100,
+            _oldDelegations,
+            _newDelegations
+        );
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        uint256 _logLength = entries.length;
 
-    assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
-    assertEq(_logLength, 1);
-  }
+        assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
+        assertEq(_logLength, 1);
+    }
 
-  function test_EmitsWhenBothDelegationsHaveTheSameDelegateeButDifferentNumerators() public {
-    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
-    _oldDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 10_000});
-    PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
-    _newDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 5000});
+    function test_EmitsWhenBothDelegationsHaveTheSameDelegateeButDifferentNumerators()
+        public
+    {
+        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
+        _oldDelegations[0] = PartialDelegation({
+            _delegatee: address(0x1),
+            _numerator: 10_000
+        });
+        PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
+        _newDelegations[0] = PartialDelegation({
+            _delegatee: address(0x1),
+            _numerator: 5000
+        });
 
-    vm.recordLogs();
-    _expectEmitDelegateVotesChangedEvents(100, _oldDelegations, _newDelegations);
-    Vm.Log[] memory entries = vm.getRecordedLogs();
-    uint256 _logLength = entries.length;
+        vm.recordLogs();
+        _expectEmitDelegateVotesChangedEvents(
+            100,
+            _oldDelegations,
+            _newDelegations
+        );
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        uint256 _logLength = entries.length;
 
-    assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
-    emit DelegateVotesChanged(address(0x1), 100, 50);
-    assertEq(_logLength, 2);
-  }
+        assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
+        emit DelegateVotesChanged(address(0x1), 100, 50);
+        assertEq(_logLength, 2);
+    }
 
-  function test_EmitsWhenOldDelegateeComesBeforeTheNewDelegatee() public {
-    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
-    _oldDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 10_000});
-    PartialDelegation[] memory _newDelegations = new PartialDelegation[](2);
-    _newDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 5000});
-    _newDelegations[1] = PartialDelegation({_delegatee: address(0x2), _numerator: 5000});
+    function test_EmitsWhenOldDelegateeComesBeforeTheNewDelegatee() public {
+        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
+        _oldDelegations[0] = PartialDelegation({
+            _delegatee: address(0x1),
+            _numerator: 10_000
+        });
+        PartialDelegation[] memory _newDelegations = new PartialDelegation[](2);
+        _newDelegations[0] = PartialDelegation({
+            _delegatee: address(0x1),
+            _numerator: 5000
+        });
+        _newDelegations[1] = PartialDelegation({
+            _delegatee: address(0x2),
+            _numerator: 5000
+        });
 
-    vm.recordLogs();
-    _expectEmitDelegateVotesChangedEvents(100, _oldDelegations, _newDelegations);
+        vm.recordLogs();
+        _expectEmitDelegateVotesChangedEvents(
+            100,
+            _oldDelegations,
+            _newDelegations
+        );
 
-    Vm.Log[] memory entries = vm.getRecordedLogs();
-    uint256 _logLength = entries.length;
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        uint256 _logLength = entries.length;
 
-    assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
-    emit DelegateVotesChanged(address(0x1), 100, 50);
-    emit DelegateVotesChanged(address(0x2), 0, 50);
-    assertEq(_logLength, 3);
-  }
+        assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
+        emit DelegateVotesChanged(address(0x1), 100, 50);
+        emit DelegateVotesChanged(address(0x2), 0, 50);
+        assertEq(_logLength, 3);
+    }
 
-  function test_EmitsWhenNewDelegateeComesBeforeTheOldDelegateeReplacingTheOldDelegatee() public {
-    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
-    _oldDelegations[0] = PartialDelegation({_delegatee: address(0x2), _numerator: 10_000});
-    PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
-    _newDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 10_000});
+    function test_EmitsWhenNewDelegateeComesBeforeTheOldDelegateeReplacingTheOldDelegatee()
+        public
+    {
+        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
+        _oldDelegations[0] = PartialDelegation({
+            _delegatee: address(0x2),
+            _numerator: 10_000
+        });
+        PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
+        _newDelegations[0] = PartialDelegation({
+            _delegatee: address(0x1),
+            _numerator: 10_000
+        });
 
-    vm.recordLogs();
-    _expectEmitDelegateVotesChangedEvents(100, _oldDelegations, _newDelegations);
+        vm.recordLogs();
+        _expectEmitDelegateVotesChangedEvents(
+            100,
+            _oldDelegations,
+            _newDelegations
+        );
 
-    Vm.Log[] memory entries = vm.getRecordedLogs();
-    uint256 _logLength = entries.length;
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        uint256 _logLength = entries.length;
 
-    assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
-    emit DelegateVotesChanged(address(0x1), 0, 100);
-    emit DelegateVotesChanged(address(0x2), 100, 0);
-    assertEq(_logLength, 3);
-  }
+        assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
+        emit DelegateVotesChanged(address(0x1), 0, 100);
+        emit DelegateVotesChanged(address(0x2), 100, 0);
+        assertEq(_logLength, 3);
+    }
 
-  function test_EmitsWhenNewDelegateeComesBeforeTheOldDelegateeIncludingThePreviousDelegatee() public {
-    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
-    _oldDelegations[0] = PartialDelegation({_delegatee: address(0x2), _numerator: 10_000});
-    PartialDelegation[] memory _newDelegations = new PartialDelegation[](2);
-    _newDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 5000});
-    _newDelegations[1] = PartialDelegation({_delegatee: address(0x2), _numerator: 5000});
+    function test_EmitsWhenNewDelegateeComesBeforeTheOldDelegateeIncludingThePreviousDelegatee()
+        public
+    {
+        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
+        _oldDelegations[0] = PartialDelegation({
+            _delegatee: address(0x2),
+            _numerator: 10_000
+        });
+        PartialDelegation[] memory _newDelegations = new PartialDelegation[](2);
+        _newDelegations[0] = PartialDelegation({
+            _delegatee: address(0x1),
+            _numerator: 5000
+        });
+        _newDelegations[1] = PartialDelegation({
+            _delegatee: address(0x2),
+            _numerator: 5000
+        });
 
-    vm.recordLogs();
-    _expectEmitDelegateVotesChangedEvents(100, _oldDelegations, _newDelegations);
+        vm.recordLogs();
+        _expectEmitDelegateVotesChangedEvents(
+            100,
+            _oldDelegations,
+            _newDelegations
+        );
 
-    Vm.Log[] memory entries = vm.getRecordedLogs();
-    uint256 _logLength = entries.length;
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        uint256 _logLength = entries.length;
 
-    assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
-    emit DelegateVotesChanged(address(0x1), 0, 50);
-    emit DelegateVotesChanged(address(0x2), 100, 50);
-    assertEq(_logLength, 3);
-  }
+        assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
+        emit DelegateVotesChanged(address(0x1), 0, 50);
+        emit DelegateVotesChanged(address(0x2), 100, 50);
+        assertEq(_logLength, 3);
+    }
 }
 
 // This contract strengthens our confidence in our test helper, `_expectEmitDelegateVotesChangedEvents` (the 4 param
 // version)
-contract ExpectEmitDelegateVotesChangedEventsDuringTransfer is PartialDelegationTest {
-  function test_EmitsWhenTransferringTokensFromAnAddressWithNoDelegationsToAnAddressWithNoDelegations() public {
-    address from = address(0x10);
-    address to = address(0x20);
-    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](0);
-    PartialDelegation[] memory _newDelegations = new PartialDelegation[](0);
+contract ExpectEmitDelegateVotesChangedEventsDuringTransfer is
+    PartialDelegationTest
+{
+    function test_EmitsWhenTransferringTokensFromAnAddressWithNoDelegationsToAnAddressWithNoDelegations()
+        public
+    {
+        address from = address(0x10);
+        address to = address(0x20);
+        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](0);
+        PartialDelegation[] memory _newDelegations = new PartialDelegation[](0);
 
-    vm.prank(from);
-    tokenProxy.mint(100);
+        vm.prank(from);
+        tokenProxy.mint(100);
 
-    vm.prank(to);
-    tokenProxy.mint(100);
+        vm.prank(to);
+        tokenProxy.mint(100);
 
-    vm.recordLogs();
-    _expectEmitDelegateVotesChangedEvents(100, 100, _oldDelegations, _newDelegations);
-    Vm.Log[] memory entries = vm.getRecordedLogs();
-    uint256 _logLength = entries.length;
+        vm.recordLogs();
+        _expectEmitDelegateVotesChangedEvents(
+            100,
+            100,
+            _oldDelegations,
+            _newDelegations
+        );
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        uint256 _logLength = entries.length;
 
-    assertEq(_logLength, 0);
-  }
+        assertEq(_logLength, 0);
+    }
 
-  function test_EmitsWhenTransferringTokensFromAnAddressWithSingleDelegateeToAnAddressWithNoDelegations() public {
-    address from = address(0x10);
-    address to = address(0x20);
-    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
-    _oldDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 10_000});
-    PartialDelegation[] memory _newDelegations = new PartialDelegation[](0);
+    function test_EmitsWhenTransferringTokensFromAnAddressWithSingleDelegateeToAnAddressWithNoDelegations()
+        public
+    {
+        address from = address(0x10);
+        address to = address(0x20);
+        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
+        _oldDelegations[0] = PartialDelegation({
+            _delegatee: address(0x1),
+            _numerator: 10_000
+        });
+        PartialDelegation[] memory _newDelegations = new PartialDelegation[](0);
 
-    vm.startPrank(from);
-    tokenProxy.mint(100);
-    tokenProxy.delegate(_oldDelegations);
-    vm.stopPrank();
+        vm.startPrank(from);
+        tokenProxy.mint(100);
+        tokenProxy.delegate(_oldDelegations);
+        vm.stopPrank();
 
-    vm.prank(to);
-    tokenProxy.mint(100);
+        vm.prank(to);
+        tokenProxy.mint(100);
 
-    vm.recordLogs();
-    _expectEmitDelegateVotesChangedEvents(100, 100, _oldDelegations, _newDelegations);
-    Vm.Log[] memory entries = vm.getRecordedLogs();
-    uint256 _logLength = entries.length;
+        vm.recordLogs();
+        _expectEmitDelegateVotesChangedEvents(
+            100,
+            100,
+            _oldDelegations,
+            _newDelegations
+        );
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        uint256 _logLength = entries.length;
 
-    emit DelegateVotesChanged(address(0x1), 100, 0);
-    assertEq(_logLength, 1);
-  }
+        emit DelegateVotesChanged(address(0x1), 100, 0);
+        assertEq(_logLength, 1);
+    }
 
-  function test_EmitsWhenTransferringTokensFromAnAddressWithSingleDelegateeToAnAddressWithASingleDelegatee() public {
-    address from = address(0x10);
-    address to = address(0x20);
-    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
-    _oldDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 10_000});
-    PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
-    _newDelegations[0] = PartialDelegation({_delegatee: address(0x2), _numerator: 10_000});
+    function test_EmitsWhenTransferringTokensFromAnAddressWithSingleDelegateeToAnAddressWithASingleDelegatee()
+        public
+    {
+        address from = address(0x10);
+        address to = address(0x20);
+        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
+        _oldDelegations[0] = PartialDelegation({
+            _delegatee: address(0x1),
+            _numerator: 10_000
+        });
+        PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
+        _newDelegations[0] = PartialDelegation({
+            _delegatee: address(0x2),
+            _numerator: 10_000
+        });
 
-    vm.startPrank(from);
-    tokenProxy.mint(100);
-    tokenProxy.delegate(_oldDelegations);
-    vm.stopPrank();
+        vm.startPrank(from);
+        tokenProxy.mint(100);
+        tokenProxy.delegate(_oldDelegations);
+        vm.stopPrank();
 
-    vm.startPrank(to);
-    tokenProxy.mint(100);
-    tokenProxy.delegate(_newDelegations);
-    vm.stopPrank();
+        vm.startPrank(to);
+        tokenProxy.mint(100);
+        tokenProxy.delegate(_newDelegations);
+        vm.stopPrank();
 
-    vm.recordLogs();
-    _expectEmitDelegateVotesChangedEvents(100, 100, _oldDelegations, _newDelegations);
-    Vm.Log[] memory entries = vm.getRecordedLogs();
-    uint256 _logLength = entries.length;
+        vm.recordLogs();
+        _expectEmitDelegateVotesChangedEvents(
+            100,
+            100,
+            _oldDelegations,
+            _newDelegations
+        );
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        uint256 _logLength = entries.length;
 
-    emit DelegateVotesChanged(address(0x1), 100, 0);
-    emit DelegateVotesChanged(address(0x2), 100, 200);
-    assertEq(_logLength, 2);
-  }
+        emit DelegateVotesChanged(address(0x1), 100, 0);
+        emit DelegateVotesChanged(address(0x2), 100, 200);
+        assertEq(_logLength, 2);
+    }
 
-  function test_EmitsWhenTransferringTokensFromAnAddressWithNoDelegationsToAnAddressWithASingleDelegatee() public {
-    address from = address(0x10);
-    address to = address(0x20);
-    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](0);
-    PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
-    _newDelegations[0] = PartialDelegation({_delegatee: address(0x2), _numerator: 10_000});
+    function test_EmitsWhenTransferringTokensFromAnAddressWithNoDelegationsToAnAddressWithASingleDelegatee()
+        public
+    {
+        address from = address(0x10);
+        address to = address(0x20);
+        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](0);
+        PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
+        _newDelegations[0] = PartialDelegation({
+            _delegatee: address(0x2),
+            _numerator: 10_000
+        });
 
-    vm.prank(from);
-    tokenProxy.mint(100);
+        vm.prank(from);
+        tokenProxy.mint(100);
 
-    vm.startPrank(to);
-    tokenProxy.mint(100);
-    tokenProxy.delegate(_newDelegations);
-    vm.stopPrank();
+        vm.startPrank(to);
+        tokenProxy.mint(100);
+        tokenProxy.delegate(_newDelegations);
+        vm.stopPrank();
 
-    vm.recordLogs();
-    _expectEmitDelegateVotesChangedEvents(100, 100, _oldDelegations, _newDelegations);
-    Vm.Log[] memory entries = vm.getRecordedLogs();
-    uint256 _logLength = entries.length;
+        vm.recordLogs();
+        _expectEmitDelegateVotesChangedEvents(
+            100,
+            100,
+            _oldDelegations,
+            _newDelegations
+        );
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        uint256 _logLength = entries.length;
 
-    emit DelegateVotesChanged(address(0x2), 100, 200);
-    assertEq(_logLength, 1);
-  }
+        emit DelegateVotesChanged(address(0x2), 100, 200);
+        assertEq(_logLength, 1);
+    }
 
-  function test_EmitsWhenTransferringTokensFromAnAddressWithNoDelegationsToAnAddressWithMultipleDelegatees() public {
-    address from = address(0x10);
-    address to = address(0x20);
-    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](0);
-    PartialDelegation[] memory _newDelegations = new PartialDelegation[](2);
-    _newDelegations[0] = PartialDelegation({_delegatee: address(0x2), _numerator: 5000});
-    _newDelegations[1] = PartialDelegation({_delegatee: address(0x3), _numerator: 5000});
+    function test_EmitsWhenTransferringTokensFromAnAddressWithNoDelegationsToAnAddressWithMultipleDelegatees()
+        public
+    {
+        address from = address(0x10);
+        address to = address(0x20);
+        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](0);
+        PartialDelegation[] memory _newDelegations = new PartialDelegation[](2);
+        _newDelegations[0] = PartialDelegation({
+            _delegatee: address(0x2),
+            _numerator: 5000
+        });
+        _newDelegations[1] = PartialDelegation({
+            _delegatee: address(0x3),
+            _numerator: 5000
+        });
 
-    vm.prank(from);
-    tokenProxy.mint(100);
+        vm.prank(from);
+        tokenProxy.mint(100);
 
-    vm.startPrank(to);
-    tokenProxy.mint(100);
-    tokenProxy.delegate(_newDelegations);
-    vm.stopPrank();
+        vm.startPrank(to);
+        tokenProxy.mint(100);
+        tokenProxy.delegate(_newDelegations);
+        vm.stopPrank();
 
-    vm.recordLogs();
-    _expectEmitDelegateVotesChangedEvents(100, 100, _oldDelegations, _newDelegations);
-    Vm.Log[] memory entries = vm.getRecordedLogs();
-    uint256 _logLength = entries.length;
+        vm.recordLogs();
+        _expectEmitDelegateVotesChangedEvents(
+            100,
+            100,
+            _oldDelegations,
+            _newDelegations
+        );
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        uint256 _logLength = entries.length;
 
-    emit DelegateVotesChanged(address(0x2), 50, 100);
-    emit DelegateVotesChanged(address(0x3), 50, 100);
-    assertEq(_logLength, 2);
-  }
+        emit DelegateVotesChanged(address(0x2), 50, 100);
+        emit DelegateVotesChanged(address(0x3), 50, 100);
+        assertEq(_logLength, 2);
+    }
 
-  function test_EmitsWhenTransferringTokensFromAnAddressWithMultipleDelegateesToAnAddressWithMultipleDelegatees()
-    public
-  {
-    address from = address(0x10);
-    address to = address(0x20);
-    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](2);
-    _oldDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 5000});
-    _oldDelegations[1] = PartialDelegation({_delegatee: address(0x2), _numerator: 5000});
+    function test_EmitsWhenTransferringTokensFromAnAddressWithMultipleDelegateesToAnAddressWithMultipleDelegatees()
+        public
+    {
+        address from = address(0x10);
+        address to = address(0x20);
+        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](2);
+        _oldDelegations[0] = PartialDelegation({
+            _delegatee: address(0x1),
+            _numerator: 5000
+        });
+        _oldDelegations[1] = PartialDelegation({
+            _delegatee: address(0x2),
+            _numerator: 5000
+        });
 
-    PartialDelegation[] memory _newDelegations = new PartialDelegation[](2);
-    _newDelegations[0] = PartialDelegation({_delegatee: address(0x3), _numerator: 5000});
-    _newDelegations[1] = PartialDelegation({_delegatee: address(0x4), _numerator: 5000});
+        PartialDelegation[] memory _newDelegations = new PartialDelegation[](2);
+        _newDelegations[0] = PartialDelegation({
+            _delegatee: address(0x3),
+            _numerator: 5000
+        });
+        _newDelegations[1] = PartialDelegation({
+            _delegatee: address(0x4),
+            _numerator: 5000
+        });
 
-    vm.startPrank(from);
-    tokenProxy.mint(100);
-    tokenProxy.delegate(_oldDelegations);
-    vm.stopPrank();
+        vm.startPrank(from);
+        tokenProxy.mint(100);
+        tokenProxy.delegate(_oldDelegations);
+        vm.stopPrank();
 
-    vm.startPrank(to);
-    tokenProxy.mint(100);
-    tokenProxy.delegate(_newDelegations);
-    vm.stopPrank();
+        vm.startPrank(to);
+        tokenProxy.mint(100);
+        tokenProxy.delegate(_newDelegations);
+        vm.stopPrank();
 
-    vm.recordLogs();
-    _expectEmitDelegateVotesChangedEvents(100, 100, _oldDelegations, _newDelegations);
-    Vm.Log[] memory entries = vm.getRecordedLogs();
-    uint256 _logLength = entries.length;
+        vm.recordLogs();
+        _expectEmitDelegateVotesChangedEvents(
+            100,
+            100,
+            _oldDelegations,
+            _newDelegations
+        );
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+        uint256 _logLength = entries.length;
 
-    emit DelegateVotesChanged(address(0x1), 50, 0);
-    emit DelegateVotesChanged(address(0x2), 50, 0);
-    emit DelegateVotesChanged(address(0x3), 50, 100);
-    emit DelegateVotesChanged(address(0x4), 50, 100);
-    assertEq(_logLength, 4);
-  }
+        emit DelegateVotesChanged(address(0x1), 50, 0);
+        emit DelegateVotesChanged(address(0x2), 50, 0);
+        emit DelegateVotesChanged(address(0x3), 50, 100);
+        emit DelegateVotesChanged(address(0x4), 50, 100);
+        assertEq(_logLength, 4);
+    }
 }

--- a/test/ERC20VotesPartialDelegationUpgradeable.t.sol
+++ b/test/ERC20VotesPartialDelegationUpgradeable.t.sol
@@ -9,2052 +9,1461 @@ import {MockERC1271Signer} from "test/helpers/MockERC1271Signer.sol";
 import {PartialDelegation, DelegationAdjustment} from "src/IVotesPartialDelegation.sol";
 
 contract PartialDelegationTest is DelegationAndEventHelpers {
-    /// @notice An invalid signature is provided.
-    error InvalidSignature();
-    /// @dev The nonce used for an `account` is not the expected current nonce.
-    error InvalidAccountNonce(address account, uint256 currentNonce);
-    /// @dev The signature used has expired.
-    error VotesExpiredSignature(uint256 expiry);
-    /// @notice Emitted when the number of delegatees exceeds the limit.
-    error PartialDelegationLimitExceeded(uint256 length, uint256 max);
-    /// @notice Emitted when the provided delegatee list is not sorted or contains duplicates.
-    error DuplicateOrUnsortedDelegatees(address delegatee);
-    /// @notice Emitted when the provided numerator is zero.
-    error InvalidNumeratorZero();
-    /// @notice Emitted when the sum of the numerators exceeds the denominator.
-    error NumeratorSumExceedsDenominator(uint256 numerator, uint96 denominator);
+  /// @notice An invalid signature is provided.
+  error InvalidSignature();
+  /// @dev The nonce used for an `account` is not the expected current nonce.
+  error InvalidAccountNonce(address account, uint256 currentNonce);
+  /// @dev The signature used has expired.
+  error VotesExpiredSignature(uint256 expiry);
+  /// @notice Emitted when the number of delegatees exceeds the limit.
+  error PartialDelegationLimitExceeded(uint256 length, uint256 max);
+  /// @notice Emitted when the provided delegatee list is not sorted or contains duplicates.
+  error DuplicateOrUnsortedDelegatees(address delegatee);
+  /// @notice Emitted when the provided numerator is zero.
+  error InvalidNumeratorZero();
+  /// @notice Emitted when the sum of the numerators exceeds the denominator.
+  error NumeratorSumExceedsDenominator(uint256 numerator, uint96 denominator);
 
-    FakeERC20VotesPartialDelegationUpgradeable public tokenImpl;
-    FakeERC20VotesPartialDelegationUpgradeable public tokenProxy;
-    bytes32 DOMAIN_SEPARATOR;
+  FakeERC20VotesPartialDelegationUpgradeable public tokenImpl;
+  FakeERC20VotesPartialDelegationUpgradeable public tokenProxy;
+  bytes32 DOMAIN_SEPARATOR;
 
-    function setUp() public virtual {
-        tokenImpl = new FakeERC20VotesPartialDelegationUpgradeable();
-        tokenProxy = FakeERC20VotesPartialDelegationUpgradeable(
-            address(new ERC1967Proxy(address(tokenImpl), ""))
-        );
-        tokenProxy.initialize();
-        DelegationAndEventHelpers.initialize(address(tokenProxy));
-        // TODO: try to build this with contract state rather than fixed values
-        DOMAIN_SEPARATOR = keccak256(
-            abi.encode(
-                keccak256(
-                    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
-                ),
-                keccak256("Fake Token"),
-                keccak256("1"),
-                block.chainid,
-                address(tokenProxy)
-            )
-        );
+  function setUp() public virtual {
+    tokenImpl = new FakeERC20VotesPartialDelegationUpgradeable();
+    tokenProxy = FakeERC20VotesPartialDelegationUpgradeable(address(new ERC1967Proxy(address(tokenImpl), "")));
+    tokenProxy.initialize();
+    DelegationAndEventHelpers.initialize(address(tokenProxy));
+    // TODO: try to build this with contract state rather than fixed values
+    DOMAIN_SEPARATOR = keccak256(
+      abi.encode(
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+        keccak256("Fake Token"),
+        keccak256("1"),
+        block.chainid,
+        address(tokenProxy)
+      )
+    );
+  }
+
+  function assertEq(PartialDelegation[] memory a, PartialDelegation[] memory b) public {
+    assertEq(a.length, b.length, "length mismatch");
+    for (uint256 i = 0; i < a.length; i++) {
+      assertEq(a[i]._delegatee, b[i]._delegatee, "delegatee mismatch");
+      assertEq(a[i]._numerator, b[i]._numerator, "numerator mismatch");
     }
+  }
 
-    function assertEq(
-        PartialDelegation[] memory a,
-        PartialDelegation[] memory b
-    ) public {
-        assertEq(a.length, b.length, "length mismatch");
-        for (uint256 i = 0; i < a.length; i++) {
-            assertEq(a[i]._delegatee, b[i]._delegatee, "delegatee mismatch");
-            assertEq(a[i]._numerator, b[i]._numerator, "numerator mismatch");
+  function assertCorrectVotes(PartialDelegation[] memory _delegations, uint256 _amount) internal {
+    DelegationAdjustment[] memory _votes = tokenProxy.exposed_calculateWeightDistribution(_delegations, _amount);
+    uint256 _totalWeight = 0;
+    for (uint256 i = 0; i < _delegations.length; i++) {
+      uint256 _expectedVoteWeight = _delegations[i]._delegatee == address(0) ? 0 : _votes[i]._amount;
+      assertEq(
+        tokenProxy.getVotes(_delegations[i]._delegatee), _expectedVoteWeight, "incorrect vote weight for delegate"
+      );
+      _totalWeight += _votes[i]._amount;
+    }
+    assertLe(_totalWeight, _amount, "incorrect total weight");
+  }
+
+  function assertCorrectPastVotes(PartialDelegation[] memory _delegations, uint256 _amount, uint256 _timepoint)
+    internal
+  {
+    DelegationAdjustment[] memory _votes = tokenProxy.exposed_calculateWeightDistribution(_delegations, _amount);
+    uint256 _totalWeight = 0;
+    for (uint256 i = 0; i < _delegations.length; i++) {
+      uint256 _expectedVoteWeight = _votes[i]._amount;
+      assertEq(
+        tokenProxy.getPastVotes(_delegations[i]._delegatee, _timepoint),
+        _expectedVoteWeight,
+        "incorrect past vote weight for delegate"
+      );
+      _totalWeight += _votes[i]._amount;
+    }
+    assertLe(_totalWeight, _amount, "incorrect total weight");
+  }
+
+  function _mint(address _to, uint256 _amount) internal {
+    vm.prank(_to);
+    tokenProxy.mint(_amount);
+  }
+
+  function _createSingleFullDelegation(address _delegatee) internal view returns (PartialDelegation[] memory) {
+    PartialDelegation[] memory delegations = new PartialDelegation[](1);
+    delegations[0] = PartialDelegation(_delegatee, tokenProxy.DENOMINATOR());
+    return delegations;
+  }
+
+  function _expectEmitDelegateVotesChangedEvents(
+    uint256 _amount,
+    uint256 _toExistingBalance,
+    PartialDelegation[] memory _fromPartialDelegations,
+    PartialDelegation[] memory _toPartialDelegations
+  ) internal {
+    DelegationAdjustment[] memory _fromVotes =
+      tokenProxy.exposed_calculateWeightDistribution(_fromPartialDelegations, _amount);
+    DelegationAdjustment[] memory _toInitialVotes =
+      tokenProxy.exposed_calculateWeightDistribution(_toPartialDelegations, _toExistingBalance);
+    DelegationAdjustment[] memory _toVotes =
+      tokenProxy.exposed_calculateWeightDistribution(_toPartialDelegations, _amount + _toExistingBalance);
+
+    uint256 i;
+    uint256 j;
+    while (i < _fromPartialDelegations.length || j < _toPartialDelegations.length) {
+      // If both delegations have the same delegatee
+      if (
+        i < _fromPartialDelegations.length && j < _toPartialDelegations.length
+          && _fromPartialDelegations[i]._delegatee == _toPartialDelegations[j]._delegatee
+      ) {
+        // if the numerator is different
+        if (_fromPartialDelegations[i]._numerator != _toPartialDelegations[j]._numerator) {
+          if (_toVotes[j]._amount != 0 || _fromVotes[j]._amount != 0) {
+            vm.expectEmit();
+            emit DelegateVotesChanged(_fromPartialDelegations[i]._delegatee, _fromVotes[j]._amount, _toVotes[j]._amount);
+          }
         }
-    }
-
-    function assertCorrectVotes(
-        PartialDelegation[] memory _delegations,
-        uint256 _amount
-    ) internal {
-        DelegationAdjustment[] memory _votes = tokenProxy
-            .exposed_calculateWeightDistribution(_delegations, _amount);
-        uint256 _totalWeight = 0;
-        for (uint256 i = 0; i < _delegations.length; i++) {
-            uint256 _expectedVoteWeight = _delegations[i]._delegatee ==
-                address(0)
-                ? 0
-                : _votes[i]._amount;
-            assertEq(
-                tokenProxy.getVotes(_delegations[i]._delegatee),
-                _expectedVoteWeight,
-                "incorrect vote weight for delegate"
-            );
-            _totalWeight += _votes[i]._amount;
+        i++;
+        j++;
+        // Old delegatee comes before the new delegatee OR new delegatees have been exhausted
+      } else if (
+        j == _toPartialDelegations.length
+          || (
+            i != _fromPartialDelegations.length
+              && _fromPartialDelegations[i]._delegatee < _toPartialDelegations[j]._delegatee
+          )
+      ) {
+        if (_fromVotes[i]._amount != 0) {
+          vm.expectEmit();
+          emit DelegateVotesChanged(_fromPartialDelegations[i]._delegatee, _fromVotes[i]._amount, 0);
         }
-        assertLe(_totalWeight, _amount, "incorrect total weight");
-    }
-
-    function assertCorrectPastVotes(
-        PartialDelegation[] memory _delegations,
-        uint256 _amount,
-        uint256 _timepoint
-    ) internal {
-        DelegationAdjustment[] memory _votes = tokenProxy
-            .exposed_calculateWeightDistribution(_delegations, _amount);
-        uint256 _totalWeight = 0;
-        for (uint256 i = 0; i < _delegations.length; i++) {
-            uint256 _expectedVoteWeight = _votes[i]._amount;
-            assertEq(
-                tokenProxy.getPastVotes(_delegations[i]._delegatee, _timepoint),
-                _expectedVoteWeight,
-                "incorrect past vote weight for delegate"
-            );
-            _totalWeight += _votes[i]._amount;
+        i++;
+        // If new delegatee comes before the old delegatee OR old delegatees have been exhausted
+      } else {
+        // If the new delegatee vote weight is not the same as its previous vote weight
+        if (_toVotes[j]._amount != 0 && _toVotes[j]._amount != _toInitialVotes[j]._amount) {
+          vm.expectEmit();
+          emit DelegateVotesChanged(
+            _toPartialDelegations[j]._delegatee, _toInitialVotes[j]._amount, _toVotes[j]._amount
+          );
         }
-        assertLe(_totalWeight, _amount, "incorrect total weight");
+        j++;
+      }
     }
+  }
 
-    function _mint(address _to, uint256 _amount) internal {
-        vm.prank(_to);
-        tokenProxy.mint(_amount);
-    }
+  function _sign(uint256 _privateKey, bytes32 _messageHash) internal pure returns (bytes memory) {
+    (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_privateKey, _messageHash);
+    return abi.encodePacked(_r, _s, _v);
+  }
 
-    function _createSingleFullDelegation(
-        address _delegatee
-    ) internal view returns (PartialDelegation[] memory) {
-        PartialDelegation[] memory delegations = new PartialDelegation[](1);
-        delegations[0] = PartialDelegation(
-            _delegatee,
-            tokenProxy.DENOMINATOR()
-        );
-        return delegations;
-    }
-
-    function _expectEmitDelegateVotesChangedEvents(
-        uint256 _amount,
-        uint256 _toExistingBalance,
-        PartialDelegation[] memory _fromPartialDelegations,
-        PartialDelegation[] memory _toPartialDelegations
-    ) internal {
-        DelegationAdjustment[] memory _fromVotes = tokenProxy
-            .exposed_calculateWeightDistribution(
-                _fromPartialDelegations,
-                _amount
-            );
-        DelegationAdjustment[] memory _toInitialVotes = tokenProxy
-            .exposed_calculateWeightDistribution(
-                _toPartialDelegations,
-                _toExistingBalance
-            );
-        DelegationAdjustment[] memory _toVotes = tokenProxy
-            .exposed_calculateWeightDistribution(
-                _toPartialDelegations,
-                _amount + _toExistingBalance
-            );
-
-        uint256 i;
-        uint256 j;
-        while (
-            i < _fromPartialDelegations.length ||
-            j < _toPartialDelegations.length
-        ) {
-            // If both delegations have the same delegatee
-            if (
-                i < _fromPartialDelegations.length &&
-                j < _toPartialDelegations.length &&
-                _fromPartialDelegations[i]._delegatee ==
-                _toPartialDelegations[j]._delegatee
-            ) {
-                // if the numerator is different
-                if (
-                    _fromPartialDelegations[i]._numerator !=
-                    _toPartialDelegations[j]._numerator
-                ) {
-                    if (
-                        _toVotes[j]._amount != 0 || _fromVotes[j]._amount != 0
-                    ) {
-                        vm.expectEmit();
-                        emit DelegateVotesChanged(
-                            _fromPartialDelegations[i]._delegatee,
-                            _fromVotes[j]._amount,
-                            _toVotes[j]._amount
-                        );
-                    }
-                }
-                i++;
-                j++;
-                // Old delegatee comes before the new delegatee OR new delegatees have been exhausted
-            } else if (
-                j == _toPartialDelegations.length ||
-                (i != _fromPartialDelegations.length &&
-                    _fromPartialDelegations[i]._delegatee <
-                    _toPartialDelegations[j]._delegatee)
-            ) {
-                if (_fromVotes[i]._amount != 0) {
-                    vm.expectEmit();
-                    emit DelegateVotesChanged(
-                        _fromPartialDelegations[i]._delegatee,
-                        _fromVotes[i]._amount,
-                        0
-                    );
-                }
-                i++;
-                // If new delegatee comes before the old delegatee OR old delegatees have been exhausted
-            } else {
-                // If the new delegatee vote weight is not the same as its previous vote weight
-                if (
-                    _toVotes[j]._amount != 0 &&
-                    _toVotes[j]._amount != _toInitialVotes[j]._amount
-                ) {
-                    vm.expectEmit();
-                    emit DelegateVotesChanged(
-                        _toPartialDelegations[j]._delegatee,
-                        _toInitialVotes[j]._amount,
-                        _toVotes[j]._amount
-                    );
-                }
-                j++;
-            }
-        }
-    }
-
-    function _sign(
-        uint256 _privateKey,
-        bytes32 _messageHash
-    ) internal pure returns (bytes memory) {
-        (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_privateKey, _messageHash);
-        return abi.encodePacked(_r, _s, _v);
-    }
-
-    function _hash(
-        PartialDelegation memory partialDelegation
-    ) internal view returns (bytes32) {
-        return
-            keccak256(
-                abi.encode(
-                    tokenProxy.PARTIAL_DELEGATION_TYPEHASH(),
-                    partialDelegation._delegatee,
-                    partialDelegation._numerator
-                )
-            );
-    }
+  function _hash(PartialDelegation memory partialDelegation) internal view returns (bytes32) {
+    return keccak256(
+      abi.encode(tokenProxy.PARTIAL_DELEGATION_TYPEHASH(), partialDelegation._delegatee, partialDelegation._numerator)
+    );
+  }
 }
 
 contract Delegate is PartialDelegationTest {
-    function testFuzz_DelegatesToAnySingleNonZeroAddress(
-        address _actor,
-        address _delegatee,
-        uint96 _numerator,
-        uint256 _amount
-    ) public {
-        vm.assume(_actor != address(0));
-        vm.assume(_delegatee != address(0));
-        _numerator = uint96(bound(_numerator, 1, tokenProxy.DENOMINATOR()));
-        _amount = bound(_amount, 0, type(uint208).max);
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-        PartialDelegation[] memory delegations = new PartialDelegation[](1);
-        delegations[0] = PartialDelegation(_delegatee, _numerator);
-        tokenProxy.delegate(delegations);
-        vm.stopPrank();
-        assertEq(tokenProxy.delegates(_actor), delegations);
-        DelegationAdjustment[] memory adjustments = tokenProxy
-            .exposed_calculateWeightDistribution(delegations, _amount);
-        assertEq(tokenProxy.getVotes(_delegatee), adjustments[0]._amount);
+  function testFuzz_DelegatesToAnySingleNonZeroAddress(
+    address _actor,
+    address _delegatee,
+    uint96 _numerator,
+    uint256 _amount
+  ) public {
+    vm.assume(_actor != address(0));
+    vm.assume(_delegatee != address(0));
+    _numerator = uint96(bound(_numerator, 1, tokenProxy.DENOMINATOR()));
+    _amount = bound(_amount, 0, type(uint208).max);
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    PartialDelegation[] memory delegations = new PartialDelegation[](1);
+    delegations[0] = PartialDelegation(_delegatee, _numerator);
+    tokenProxy.delegate(delegations);
+    vm.stopPrank();
+    assertEq(tokenProxy.delegates(_actor), delegations);
+    DelegationAdjustment[] memory adjustments = tokenProxy.exposed_calculateWeightDistribution(delegations, _amount);
+    assertEq(tokenProxy.getVotes(_delegatee), adjustments[0]._amount);
+  }
+
+  function testFuzz_DelegatesOnlyToZeroAddress(address _actor, uint96 _numerator, uint256 _amount) public {
+    vm.assume(_actor != address(0));
+    address _delegatee = address(0);
+    _numerator = uint96(bound(_numerator, 1, tokenProxy.DENOMINATOR()));
+    _amount = bound(_amount, 0, type(uint208).max);
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    PartialDelegation[] memory delegations = new PartialDelegation[](1);
+    delegations[0] = PartialDelegation(_delegatee, _numerator);
+    tokenProxy.delegate(delegations);
+    vm.stopPrank();
+    assertEq(tokenProxy.delegates(_actor), delegations);
+    assertEq(tokenProxy.getVotes(_delegatee), 0);
+  }
+
+  function testFuzz_DelegatesToTwoAddresses(
+    address _actor,
+    address _delegatee1,
+    address _delegatee2,
+    uint256 _amount,
+    uint96 _numerator1,
+    uint96 _numerator2
+  ) public {
+    vm.assume(_actor != address(0));
+    vm.assume(_delegatee1 != address(0));
+    vm.assume(_delegatee2 != address(0));
+    vm.assume(_delegatee1 < _delegatee2);
+    _amount = bound(_amount, 0, type(uint208).max);
+    _numerator1 = uint96(bound(_numerator1, 1, tokenProxy.DENOMINATOR() - 1));
+    _numerator2 = uint96(bound(_numerator2, 1, tokenProxy.DENOMINATOR() - _numerator1));
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    PartialDelegation[] memory delegations = new PartialDelegation[](2);
+    delegations[0] = PartialDelegation(_delegatee1, _numerator1);
+    delegations[1] = PartialDelegation(_delegatee2, _numerator2);
+    tokenProxy.delegate(delegations);
+    vm.stopPrank();
+    assertEq(tokenProxy.delegates(_actor), delegations);
+    assertCorrectVotes(delegations, _amount);
+  }
+
+  function testFuzz_DelegatesToNAddresses(address _actor, uint256 _amount, uint256 _n, uint256 _seed) public {
+    vm.assume(_actor != address(0));
+    _amount = bound(_amount, 0, type(uint208).max);
+    _n = bound(_n, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+    PartialDelegation[] memory delegations = _createValidPartialDelegation(_n, _seed);
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    tokenProxy.delegate(delegations);
+    vm.stopPrank();
+    assertEq(tokenProxy.delegates(_actor), delegations);
+    assertCorrectVotes(delegations, _amount);
+  }
+
+  function testFuzz_DelegatesToNAddressesAndThenDelegatesToOtherAddresses(
+    address _actor,
+    uint256 _amount,
+    uint256 _n,
+    uint256 _seed
+  ) public {
+    vm.assume(_actor != address(0));
+    _amount = bound(_amount, 0, type(uint208).max);
+    _n = bound(_n, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+    PartialDelegation[] memory delegations = _createValidPartialDelegation(_n, _seed);
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    tokenProxy.delegate(delegations);
+    vm.stopPrank();
+    assertEq(tokenProxy.delegates(_actor), delegations);
+    PartialDelegation[] memory newDelegations = _createValidPartialDelegation(
+      /* setting n to 0 here means seed will
+      generate random n */
+      0,
+      uint256(keccak256(abi.encode(_seed)))
+    );
+    vm.startPrank(_actor);
+    tokenProxy.delegate(newDelegations);
+    vm.stopPrank();
+    assertEq(tokenProxy.delegates(_actor), newDelegations);
+    assertCorrectVotes(newDelegations, _amount);
+    // initial delegates should have 0 vote power (assuming set union is empty)
+    for (uint256 i = 0; i < delegations.length; i++) {
+      assertEq(tokenProxy.getVotes(delegations[i]._delegatee), 0, "initial delegate has vote power");
+    }
+  }
+
+  function testFuzz_EmitsDelegateChangedEvents(address _actor, uint256 _amount, uint256 _n, uint256 _seed) public {
+    vm.assume(_actor != address(0));
+    _amount = bound(_amount, 0, type(uint208).max);
+    _n = bound(_n, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+    PartialDelegation[] memory delegations = _createValidPartialDelegation(_n, _seed);
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+
+    vm.expectEmit();
+    emit DelegateChanged(_actor, new PartialDelegation[](0), delegations);
+    tokenProxy.delegate(delegations);
+    vm.stopPrank();
+  }
+
+  function testFuzz_EmitsDelegateVotesChanged(address _actor, uint256 _amount, uint256 _n, uint256 _seed) public {
+    vm.assume(_actor != address(0));
+    _amount = bound(_amount, 0, type(uint208).max);
+    _n = bound(_n, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+    PartialDelegation[] memory delegations = _createValidPartialDelegation(_n, _seed);
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+
+    _expectEmitDelegateVotesChangedEvents(_amount, new PartialDelegation[](0), delegations);
+    tokenProxy.delegate(delegations);
+    vm.stopPrank();
+  }
+
+  function testFuzz_EmitsDelegateChangedEventsWhenDelegateesAreRemoved(
+    address _actor,
+    uint256 _amount,
+    uint256 _oldN,
+    uint256 _numOfDelegateesToRemove,
+    uint256 _seed
+  ) public {
+    vm.assume(_actor != address(0));
+    _amount = bound(_amount, 0, type(uint208).max);
+    _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+    _numOfDelegateesToRemove = bound(_numOfDelegateesToRemove, 0, _oldN - 1);
+    PartialDelegation[] memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    tokenProxy.delegate(oldDelegations);
+
+    PartialDelegation[] memory newDelegations = new PartialDelegation[](_oldN - _numOfDelegateesToRemove);
+    for (uint256 i; i < newDelegations.length; i++) {
+      newDelegations[i] = oldDelegations[i];
     }
 
-    function testFuzz_DelegatesOnlyToZeroAddress(
-        address _actor,
-        uint96 _numerator,
-        uint256 _amount
-    ) public {
-        vm.assume(_actor != address(0));
-        address _delegatee = address(0);
-        _numerator = uint96(bound(_numerator, 1, tokenProxy.DENOMINATOR()));
-        _amount = bound(_amount, 0, type(uint208).max);
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-        PartialDelegation[] memory delegations = new PartialDelegation[](1);
-        delegations[0] = PartialDelegation(_delegatee, _numerator);
-        tokenProxy.delegate(delegations);
-        vm.stopPrank();
-        assertEq(tokenProxy.delegates(_actor), delegations);
-        assertEq(tokenProxy.getVotes(_delegatee), 0);
+    vm.expectEmit();
+    emit DelegateChanged(_actor, oldDelegations, newDelegations);
+    tokenProxy.delegate(newDelegations);
+    vm.stopPrank();
+  }
+
+  function testFuzz_EmitsDelegateChangedEventsWhenAllNumeratorsForCurrentDelegateesAreChanged(
+    address _actor,
+    uint256 _amount,
+    uint256 _oldN,
+    uint256 _newN,
+    uint256 _seed
+  ) public {
+    vm.assume(_actor != address(0));
+    _amount = bound(_amount, 0, type(uint208).max);
+    _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+    _newN = bound(_newN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+    PartialDelegation[] memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    tokenProxy.delegate(oldDelegations);
+    PartialDelegation[] memory newDelegations = oldDelegations;
+
+    // Arthimatic overflow/underflow error without this bounding.
+    _seed = bound(
+      _seed,
+      1,
+      /* private key can't be bigger than secp256k1 curve order */
+      115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 - 1
+    );
+    uint96 _totalNumerator;
+    for (uint256 i = 0; i < _oldN; i++) {
+      uint96 _numerator = uint96(
+        bound(
+          uint256(keccak256(abi.encode(_seed + i))) % tokenProxy.DENOMINATOR(), // initial value of the numerator
+          1,
+          tokenProxy.DENOMINATOR() - _totalNumerator - (_oldN - i) // ensure that there is enough numerator left for the
+            // remaining delegations
+        )
+      );
+      newDelegations[i]._numerator = _numerator;
+      _totalNumerator += _numerator;
     }
 
-    function testFuzz_DelegatesToTwoAddresses(
-        address _actor,
-        address _delegatee1,
-        address _delegatee2,
-        uint256 _amount,
-        uint96 _numerator1,
-        uint96 _numerator2
-    ) public {
-        vm.assume(_actor != address(0));
-        vm.assume(_delegatee1 != address(0));
-        vm.assume(_delegatee2 != address(0));
-        vm.assume(_delegatee1 < _delegatee2);
-        _amount = bound(_amount, 0, type(uint208).max);
-        _numerator1 = uint96(
-            bound(_numerator1, 1, tokenProxy.DENOMINATOR() - 1)
-        );
-        _numerator2 = uint96(
-            bound(_numerator2, 1, tokenProxy.DENOMINATOR() - _numerator1)
-        );
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-        PartialDelegation[] memory delegations = new PartialDelegation[](2);
-        delegations[0] = PartialDelegation(_delegatee1, _numerator1);
-        delegations[1] = PartialDelegation(_delegatee2, _numerator2);
-        tokenProxy.delegate(delegations);
-        vm.stopPrank();
-        assertEq(tokenProxy.delegates(_actor), delegations);
-        assertCorrectVotes(delegations, _amount);
+    vm.expectEmit();
+    emit DelegateChanged(_actor, oldDelegations, newDelegations);
+    tokenProxy.delegate(newDelegations);
+    vm.stopPrank();
+  }
+
+  function testFuzz_EmitsDelegateChangedEventsWhenAllDelegatesAreReplaced(
+    address _actor,
+    uint256 _amount,
+    uint256 _oldN,
+    uint256 _newN,
+    uint256 _seed
+  ) public {
+    vm.assume(_actor != address(0));
+    _amount = bound(_amount, 0, type(uint208).max);
+    _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+    _newN = bound(_newN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+    PartialDelegation[] memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    tokenProxy.delegate(oldDelegations);
+
+    PartialDelegation[] memory newDelegations =
+      _createValidPartialDelegation(_newN, uint256(keccak256(abi.encode(_seed))));
+    vm.expectEmit();
+    emit DelegateChanged(_actor, oldDelegations, newDelegations);
+    tokenProxy.delegate(newDelegations);
+    vm.stopPrank();
+  }
+
+  function testFuzz_EmitsDelegateVotesChangedEventsWhenAllNumeratorsForCurrentDelegateesAreChanged(
+    address _actor,
+    uint256 _amount,
+    uint256 _oldN,
+    uint256 _newN,
+    uint256 _seed
+  ) public {
+    vm.assume(_actor != address(0));
+    _amount = bound(_amount, 0, type(uint208).max);
+    _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+    _newN = bound(_newN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+    PartialDelegation[] memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    tokenProxy.delegate(oldDelegations);
+    PartialDelegation[] memory newDelegations = oldDelegations;
+
+    _seed = bound(
+      _seed,
+      1,
+      /* private key can't be bigger than secp256k1 curve order */
+      115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 - 1
+    );
+    uint96 _totalNumerator;
+    for (uint256 i = 0; i < _oldN; i++) {
+      uint96 _numerator = uint96(
+        bound(
+          uint256(keccak256(abi.encode(_seed + i))) % tokenProxy.DENOMINATOR(), // initial value of the numerator
+          1,
+          tokenProxy.DENOMINATOR() - _totalNumerator - (_oldN - i) // ensure that there is enough numerator left for the
+            // remaining delegations
+        )
+      );
+      newDelegations[i]._numerator = _numerator;
+      _totalNumerator += _numerator;
     }
 
-    function testFuzz_DelegatesToNAddresses(
-        address _actor,
-        uint256 _amount,
-        uint256 _n,
-        uint256 _seed
-    ) public {
-        vm.assume(_actor != address(0));
-        _amount = bound(_amount, 0, type(uint208).max);
-        _n = bound(_n, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-        PartialDelegation[] memory delegations = _createValidPartialDelegation(
-            _n,
-            _seed
-        );
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-        tokenProxy.delegate(delegations);
-        vm.stopPrank();
-        assertEq(tokenProxy.delegates(_actor), delegations);
-        assertCorrectVotes(delegations, _amount);
+    _expectEmitDelegateVotesChangedEvents(_amount, oldDelegations, newDelegations);
+    tokenProxy.delegate(newDelegations);
+    vm.stopPrank();
+  }
+
+  function testFuzz_EmitsDelegateVotesChangedEventsWhenDelegateesAreRemoved(
+    address _actor,
+    uint256 _amount,
+    uint256 _oldN,
+    uint256 _numOfDelegateesToRemove,
+    uint256 _seed
+  ) public {
+    vm.assume(_actor != address(0));
+    _amount = bound(_amount, 0, type(uint208).max);
+    _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+    _numOfDelegateesToRemove = bound(_numOfDelegateesToRemove, 0, _oldN - 1);
+    PartialDelegation[] memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    tokenProxy.delegate(oldDelegations);
+
+    PartialDelegation[] memory newDelegations = new PartialDelegation[](_oldN - _numOfDelegateesToRemove);
+    for (uint256 i; i < newDelegations.length; i++) {
+      newDelegations[i] = oldDelegations[i];
     }
 
-    function testFuzz_DelegatesToNAddressesAndThenDelegatesToOtherAddresses(
-        address _actor,
-        uint256 _amount,
-        uint256 _n,
-        uint256 _seed
-    ) public {
-        vm.assume(_actor != address(0));
-        _amount = bound(_amount, 0, type(uint208).max);
-        _n = bound(_n, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-        PartialDelegation[] memory delegations = _createValidPartialDelegation(
-            _n,
-            _seed
-        );
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-        tokenProxy.delegate(delegations);
-        vm.stopPrank();
-        assertEq(tokenProxy.delegates(_actor), delegations);
-        PartialDelegation[]
-            memory newDelegations = _createValidPartialDelegation(
-                /* setting n to 0 here means seed will
-      generate random n */ 0,
-                uint256(keccak256(abi.encode(_seed)))
-            );
-        vm.startPrank(_actor);
-        tokenProxy.delegate(newDelegations);
-        vm.stopPrank();
-        assertEq(tokenProxy.delegates(_actor), newDelegations);
-        assertCorrectVotes(newDelegations, _amount);
-        // initial delegates should have 0 vote power (assuming set union is empty)
-        for (uint256 i = 0; i < delegations.length; i++) {
-            assertEq(
-                tokenProxy.getVotes(delegations[i]._delegatee),
-                0,
-                "initial delegate has vote power"
-            );
-        }
+    _expectEmitDelegateVotesChangedEvents(_amount, oldDelegations, newDelegations);
+    tokenProxy.delegate(newDelegations);
+    vm.stopPrank();
+  }
+
+  function testFuzz_EmitsDelegateVotesChangedEventsWhenAllDelegatesAreReplaced(
+    address _actor,
+    uint256 _amount,
+    uint256 _oldN,
+    uint256 _newN,
+    uint256 _seed
+  ) public {
+    vm.assume(_actor != address(0));
+    _amount = bound(_amount, 0, type(uint208).max);
+    _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+    _newN = bound(_newN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+
+    PartialDelegation[] memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    tokenProxy.delegate(oldDelegations);
+
+    PartialDelegation[] memory newDelegations =
+      _createValidPartialDelegation(_newN, uint256(keccak256(abi.encode(_seed))));
+    _expectEmitDelegateVotesChangedEvents(_amount, oldDelegations, newDelegations);
+    tokenProxy.delegate(newDelegations);
+    vm.stopPrank();
+  }
+
+  function testFuzz_RevertIf_DelegationArrayIncludesDuplicates(
+    address _actor,
+    address _delegatee,
+    uint256 _amount,
+    uint96 _numerator
+  ) public {
+    vm.assume(_actor != address(0));
+    vm.assume(_delegatee != address(0));
+    _amount = bound(_amount, 0, type(uint208).max);
+    _numerator = uint96(bound(_numerator, 1, tokenProxy.DENOMINATOR() - 1));
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    PartialDelegation[] memory delegations = new PartialDelegation[](2);
+    delegations[0] = PartialDelegation(_delegatee, _numerator);
+    delegations[1] = PartialDelegation(_delegatee, tokenProxy.DENOMINATOR() - _numerator);
+    vm.expectRevert();
+    tokenProxy.delegate(delegations);
+    vm.stopPrank();
+  }
+
+  function testFuzz_RevertIf_DelegationArrayNumeratorsSumToGreaterThanDenominator(
+    address _actor,
+    address _delegatee1,
+    address _delegatee2,
+    uint256 _amount,
+    uint96 _numerator1,
+    uint96 _numerator2
+  ) public {
+    vm.assume(_actor != address(0));
+    vm.assume(_delegatee1 != address(0));
+    vm.assume(_delegatee2 != address(0));
+    vm.assume(_delegatee1 < _delegatee2);
+    _amount = bound(_amount, 0, type(uint208).max);
+    _numerator1 = uint96(bound(_numerator1, 1, tokenProxy.DENOMINATOR()));
+    _numerator2 = uint96(bound(_numerator2, tokenProxy.DENOMINATOR() - _numerator1 + 1, type(uint96).max - _numerator1));
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    PartialDelegation[] memory delegations = new PartialDelegation[](2);
+    delegations[0] = PartialDelegation(_delegatee1, _numerator1);
+    delegations[1] = PartialDelegation(_delegatee2, _numerator2);
+    vm.expectRevert();
+    tokenProxy.delegate(delegations);
+    vm.stopPrank();
+  }
+
+  function testFuzz_RevertIf_DelegationNumeratorTooLarge(
+    address _actor,
+    address _delegatee,
+    uint256 _amount,
+    uint96 _numerator
+  ) public {
+    vm.assume(_actor != address(0));
+    vm.assume(_delegatee != address(0));
+    _numerator = uint96(bound(_numerator, tokenProxy.DENOMINATOR() + 1, type(uint96).max));
+    _amount = bound(_amount, 0, type(uint208).max);
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    PartialDelegation[] memory delegations = new PartialDelegation[](1);
+    delegations[0] = PartialDelegation(_delegatee, _numerator);
+    vm.expectRevert();
+    tokenProxy.delegate(delegations);
+    vm.stopPrank();
+  }
+
+  function testFuzz_RevertIf_PartialDelegationLimitExceeded(
+    address _actor,
+    uint256 _amount,
+    uint256 _numOfDelegatees,
+    uint256 _seed
+  ) public {
+    vm.assume(_actor != address(0));
+    _amount = bound(_amount, 0, type(uint208).max);
+    _numOfDelegatees =
+      bound(_numOfDelegatees, tokenProxy.MAX_PARTIAL_DELEGATIONS() + 1, tokenProxy.MAX_PARTIAL_DELEGATIONS() + 500);
+    PartialDelegation[] memory delegations = _createValidPartialDelegation(_numOfDelegatees, _seed);
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        PartialDelegationLimitExceeded.selector, _numOfDelegatees, tokenProxy.MAX_PARTIAL_DELEGATIONS()
+      )
+    );
+    tokenProxy.delegate(delegations);
+    vm.stopPrank();
+  }
+
+  function testFuzz_RevertIf_DuplicateOrUnsortedDelegatees(
+    address _actor,
+    uint256 _amount,
+    uint256 _numOfDelegatees,
+    address _replacedDelegatee,
+    uint256 _seed
+  ) public {
+    vm.assume(_actor != address(0));
+    _amount = bound(_amount, 0, type(uint208).max);
+    _numOfDelegatees = bound(_numOfDelegatees, 2, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+    PartialDelegation[] memory delegations = _createValidPartialDelegation(_numOfDelegatees, _seed);
+    address lastDelegatee = delegations[delegations.length - 1]._delegatee;
+    vm.assume(_replacedDelegatee <= lastDelegatee);
+    delegations[delegations.length - 1]._delegatee = _replacedDelegatee;
+
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    vm.expectRevert(abi.encodeWithSelector(DuplicateOrUnsortedDelegatees.selector, _replacedDelegatee));
+    tokenProxy.delegate(delegations);
+    vm.stopPrank();
+  }
+
+  function testFuzz_RevertIf_InvalidNumeratorZero(
+    address _actor,
+    uint256 _amount,
+    uint256 _delegationIndex,
+    uint256 _seed
+  ) public {
+    vm.assume(_actor != address(0));
+    _amount = bound(_amount, 0, type(uint208).max);
+    PartialDelegation[] memory delegations = _createValidPartialDelegation(0, _seed);
+    _delegationIndex = bound(_delegationIndex, 0, delegations.length - 1);
+
+    delegations[_delegationIndex]._numerator = 0;
+
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    vm.expectRevert(InvalidNumeratorZero.selector);
+    tokenProxy.delegate(delegations);
+    vm.stopPrank();
+  }
+
+  function testFuzz_RevertIf_NumeratorSumExceedsDenominator(
+    address _actor,
+    uint256 _amount,
+    uint256 _delegationIndex,
+    uint256 _seed
+  ) public {
+    vm.assume(_actor != address(0));
+    _amount = bound(_amount, 0, type(uint208).max);
+    PartialDelegation[] memory delegations = _createValidPartialDelegation(0, _seed);
+    _delegationIndex = bound(_delegationIndex, 0, delegations.length - 1);
+
+    delegations[_delegationIndex]._numerator = tokenProxy.DENOMINATOR() + 1;
+    uint256 sumOfNumerators;
+    for (uint256 i; i < delegations.length; i++) {
+      sumOfNumerators += delegations[i]._numerator;
     }
 
-    function testFuzz_EmitsDelegateChangedEvents(
-        address _actor,
-        uint256 _amount,
-        uint256 _n,
-        uint256 _seed
-    ) public {
-        vm.assume(_actor != address(0));
-        _amount = bound(_amount, 0, type(uint208).max);
-        _n = bound(_n, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-        PartialDelegation[] memory delegations = _createValidPartialDelegation(
-            _n,
-            _seed
-        );
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-
-        vm.expectEmit();
-        emit DelegateChanged(_actor, new PartialDelegation[](0), delegations);
-        tokenProxy.delegate(delegations);
-        vm.stopPrank();
-    }
-
-    function testFuzz_EmitsDelegateVotesChanged(
-        address _actor,
-        uint256 _amount,
-        uint256 _n,
-        uint256 _seed
-    ) public {
-        vm.assume(_actor != address(0));
-        _amount = bound(_amount, 0, type(uint208).max);
-        _n = bound(_n, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-        PartialDelegation[] memory delegations = _createValidPartialDelegation(
-            _n,
-            _seed
-        );
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-
-        _expectEmitDelegateVotesChangedEvents(
-            _amount,
-            new PartialDelegation[](0),
-            delegations
-        );
-        tokenProxy.delegate(delegations);
-        vm.stopPrank();
-    }
-
-    function testFuzz_EmitsDelegateChangedEventsWhenDelegateesAreRemoved(
-        address _actor,
-        uint256 _amount,
-        uint256 _oldN,
-        uint256 _numOfDelegateesToRemove,
-        uint256 _seed
-    ) public {
-        vm.assume(_actor != address(0));
-        _amount = bound(_amount, 0, type(uint208).max);
-        _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-        _numOfDelegateesToRemove = bound(
-            _numOfDelegateesToRemove,
-            0,
-            _oldN - 1
-        );
-        PartialDelegation[]
-            memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-        tokenProxy.delegate(oldDelegations);
-
-        PartialDelegation[] memory newDelegations = new PartialDelegation[](
-            _oldN - _numOfDelegateesToRemove
-        );
-        for (uint256 i; i < newDelegations.length; i++) {
-            newDelegations[i] = oldDelegations[i];
-        }
-
-        vm.expectEmit();
-        emit DelegateChanged(_actor, oldDelegations, newDelegations);
-        tokenProxy.delegate(newDelegations);
-        vm.stopPrank();
-    }
-
-    function testFuzz_EmitsDelegateChangedEventsWhenAllNumeratorsForCurrentDelegateesAreChanged(
-        address _actor,
-        uint256 _amount,
-        uint256 _oldN,
-        uint256 _newN,
-        uint256 _seed
-    ) public {
-        vm.assume(_actor != address(0));
-        _amount = bound(_amount, 0, type(uint208).max);
-        _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-        _newN = bound(_newN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-        PartialDelegation[]
-            memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-        tokenProxy.delegate(oldDelegations);
-        PartialDelegation[] memory newDelegations = oldDelegations;
-
-        // Arthimatic overflow/underflow error without this bounding.
-        _seed = bound(
-            _seed,
-            1,
-            /* private key can't be bigger than secp256k1 curve order */
-            115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 -
-                1
-        );
-        uint96 _totalNumerator;
-        for (uint256 i = 0; i < _oldN; i++) {
-            uint96 _numerator = uint96(
-                bound(
-                    uint256(keccak256(abi.encode(_seed + i))) %
-                        tokenProxy.DENOMINATOR(), // initial value of the numerator
-                    1,
-                    tokenProxy.DENOMINATOR() - _totalNumerator - (_oldN - i) // ensure that there is enough numerator left for the
-                    // remaining delegations
-                )
-            );
-            newDelegations[i]._numerator = _numerator;
-            _totalNumerator += _numerator;
-        }
-
-        vm.expectEmit();
-        emit DelegateChanged(_actor, oldDelegations, newDelegations);
-        tokenProxy.delegate(newDelegations);
-        vm.stopPrank();
-    }
-
-    function testFuzz_EmitsDelegateChangedEventsWhenAllDelegatesAreReplaced(
-        address _actor,
-        uint256 _amount,
-        uint256 _oldN,
-        uint256 _newN,
-        uint256 _seed
-    ) public {
-        vm.assume(_actor != address(0));
-        _amount = bound(_amount, 0, type(uint208).max);
-        _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-        _newN = bound(_newN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-        PartialDelegation[]
-            memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-        tokenProxy.delegate(oldDelegations);
-
-        PartialDelegation[]
-            memory newDelegations = _createValidPartialDelegation(
-                _newN,
-                uint256(keccak256(abi.encode(_seed)))
-            );
-        vm.expectEmit();
-        emit DelegateChanged(_actor, oldDelegations, newDelegations);
-        tokenProxy.delegate(newDelegations);
-        vm.stopPrank();
-    }
-
-    function testFuzz_EmitsDelegateVotesChangedEventsWhenAllNumeratorsForCurrentDelegateesAreChanged(
-        address _actor,
-        uint256 _amount,
-        uint256 _oldN,
-        uint256 _newN,
-        uint256 _seed
-    ) public {
-        vm.assume(_actor != address(0));
-        _amount = bound(_amount, 0, type(uint208).max);
-        _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-        _newN = bound(_newN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-        PartialDelegation[]
-            memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-        tokenProxy.delegate(oldDelegations);
-        PartialDelegation[] memory newDelegations = oldDelegations;
-
-        _seed = bound(
-            _seed,
-            1,
-            /* private key can't be bigger than secp256k1 curve order */
-            115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 -
-                1
-        );
-        uint96 _totalNumerator;
-        for (uint256 i = 0; i < _oldN; i++) {
-            uint96 _numerator = uint96(
-                bound(
-                    uint256(keccak256(abi.encode(_seed + i))) %
-                        tokenProxy.DENOMINATOR(), // initial value of the numerator
-                    1,
-                    tokenProxy.DENOMINATOR() - _totalNumerator - (_oldN - i) // ensure that there is enough numerator left for the
-                    // remaining delegations
-                )
-            );
-            newDelegations[i]._numerator = _numerator;
-            _totalNumerator += _numerator;
-        }
-
-        _expectEmitDelegateVotesChangedEvents(
-            _amount,
-            oldDelegations,
-            newDelegations
-        );
-        tokenProxy.delegate(newDelegations);
-        vm.stopPrank();
-    }
-
-    function testFuzz_EmitsDelegateVotesChangedEventsWhenDelegateesAreRemoved(
-        address _actor,
-        uint256 _amount,
-        uint256 _oldN,
-        uint256 _numOfDelegateesToRemove,
-        uint256 _seed
-    ) public {
-        vm.assume(_actor != address(0));
-        _amount = bound(_amount, 0, type(uint208).max);
-        _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-        _numOfDelegateesToRemove = bound(
-            _numOfDelegateesToRemove,
-            0,
-            _oldN - 1
-        );
-        PartialDelegation[]
-            memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-        tokenProxy.delegate(oldDelegations);
-
-        PartialDelegation[] memory newDelegations = new PartialDelegation[](
-            _oldN - _numOfDelegateesToRemove
-        );
-        for (uint256 i; i < newDelegations.length; i++) {
-            newDelegations[i] = oldDelegations[i];
-        }
-
-        _expectEmitDelegateVotesChangedEvents(
-            _amount,
-            oldDelegations,
-            newDelegations
-        );
-        tokenProxy.delegate(newDelegations);
-        vm.stopPrank();
-    }
-
-    function testFuzz_EmitsDelegateVotesChangedEventsWhenAllDelegatesAreReplaced(
-        address _actor,
-        uint256 _amount,
-        uint256 _oldN,
-        uint256 _newN,
-        uint256 _seed
-    ) public {
-        vm.assume(_actor != address(0));
-        _amount = bound(_amount, 0, type(uint208).max);
-        _oldN = bound(_oldN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-        _newN = bound(_newN, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
-
-        PartialDelegation[]
-            memory oldDelegations = _createValidPartialDelegation(_oldN, _seed);
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-        tokenProxy.delegate(oldDelegations);
-
-        PartialDelegation[]
-            memory newDelegations = _createValidPartialDelegation(
-                _newN,
-                uint256(keccak256(abi.encode(_seed)))
-            );
-        _expectEmitDelegateVotesChangedEvents(
-            _amount,
-            oldDelegations,
-            newDelegations
-        );
-        tokenProxy.delegate(newDelegations);
-        vm.stopPrank();
-    }
-
-    function testFuzz_RevertIf_DelegationArrayIncludesDuplicates(
-        address _actor,
-        address _delegatee,
-        uint256 _amount,
-        uint96 _numerator
-    ) public {
-        vm.assume(_actor != address(0));
-        vm.assume(_delegatee != address(0));
-        _amount = bound(_amount, 0, type(uint208).max);
-        _numerator = uint96(bound(_numerator, 1, tokenProxy.DENOMINATOR() - 1));
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-        PartialDelegation[] memory delegations = new PartialDelegation[](2);
-        delegations[0] = PartialDelegation(_delegatee, _numerator);
-        delegations[1] = PartialDelegation(
-            _delegatee,
-            tokenProxy.DENOMINATOR() - _numerator
-        );
-        vm.expectRevert();
-        tokenProxy.delegate(delegations);
-        vm.stopPrank();
-    }
-
-    function testFuzz_RevertIf_DelegationArrayNumeratorsSumToGreaterThanDenominator(
-        address _actor,
-        address _delegatee1,
-        address _delegatee2,
-        uint256 _amount,
-        uint96 _numerator1,
-        uint96 _numerator2
-    ) public {
-        vm.assume(_actor != address(0));
-        vm.assume(_delegatee1 != address(0));
-        vm.assume(_delegatee2 != address(0));
-        vm.assume(_delegatee1 < _delegatee2);
-        _amount = bound(_amount, 0, type(uint208).max);
-        _numerator1 = uint96(bound(_numerator1, 1, tokenProxy.DENOMINATOR()));
-        _numerator2 = uint96(
-            bound(
-                _numerator2,
-                tokenProxy.DENOMINATOR() - _numerator1 + 1,
-                type(uint96).max - _numerator1
-            )
-        );
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-        PartialDelegation[] memory delegations = new PartialDelegation[](2);
-        delegations[0] = PartialDelegation(_delegatee1, _numerator1);
-        delegations[1] = PartialDelegation(_delegatee2, _numerator2);
-        vm.expectRevert();
-        tokenProxy.delegate(delegations);
-        vm.stopPrank();
-    }
-
-    function testFuzz_RevertIf_DelegationNumeratorTooLarge(
-        address _actor,
-        address _delegatee,
-        uint256 _amount,
-        uint96 _numerator
-    ) public {
-        vm.assume(_actor != address(0));
-        vm.assume(_delegatee != address(0));
-        _numerator = uint96(
-            bound(_numerator, tokenProxy.DENOMINATOR() + 1, type(uint96).max)
-        );
-        _amount = bound(_amount, 0, type(uint208).max);
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-        PartialDelegation[] memory delegations = new PartialDelegation[](1);
-        delegations[0] = PartialDelegation(_delegatee, _numerator);
-        vm.expectRevert();
-        tokenProxy.delegate(delegations);
-        vm.stopPrank();
-    }
-
-    function testFuzz_RevertIf_PartialDelegationLimitExceeded(
-        address _actor,
-        uint256 _amount,
-        uint256 _numOfDelegatees,
-        uint256 _seed
-    ) public {
-        vm.assume(_actor != address(0));
-        _amount = bound(_amount, 0, type(uint208).max);
-        _numOfDelegatees = bound(
-            _numOfDelegatees,
-            tokenProxy.MAX_PARTIAL_DELEGATIONS() + 1,
-            tokenProxy.MAX_PARTIAL_DELEGATIONS() + 500
-        );
-        PartialDelegation[] memory delegations = _createValidPartialDelegation(
-            _numOfDelegatees,
-            _seed
-        );
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                PartialDelegationLimitExceeded.selector,
-                _numOfDelegatees,
-                tokenProxy.MAX_PARTIAL_DELEGATIONS()
-            )
-        );
-        tokenProxy.delegate(delegations);
-        vm.stopPrank();
-    }
-
-    function testFuzz_RevertIf_DuplicateOrUnsortedDelegatees(
-        address _actor,
-        uint256 _amount,
-        uint256 _numOfDelegatees,
-        address _replacedDelegatee,
-        uint256 _seed
-    ) public {
-        vm.assume(_actor != address(0));
-        _amount = bound(_amount, 0, type(uint208).max);
-        _numOfDelegatees = bound(
-            _numOfDelegatees,
-            2,
-            tokenProxy.MAX_PARTIAL_DELEGATIONS()
-        );
-        PartialDelegation[] memory delegations = _createValidPartialDelegation(
-            _numOfDelegatees,
-            _seed
-        );
-        address lastDelegatee = delegations[delegations.length - 1]._delegatee;
-        vm.assume(_replacedDelegatee <= lastDelegatee);
-        delegations[delegations.length - 1]._delegatee = _replacedDelegatee;
-
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                DuplicateOrUnsortedDelegatees.selector,
-                _replacedDelegatee
-            )
-        );
-        tokenProxy.delegate(delegations);
-        vm.stopPrank();
-    }
-
-    function testFuzz_RevertIf_InvalidNumeratorZero(
-        address _actor,
-        uint256 _amount,
-        uint256 _delegationIndex,
-        uint256 _seed
-    ) public {
-        vm.assume(_actor != address(0));
-        _amount = bound(_amount, 0, type(uint208).max);
-        PartialDelegation[] memory delegations = _createValidPartialDelegation(
-            0,
-            _seed
-        );
-        _delegationIndex = bound(_delegationIndex, 0, delegations.length - 1);
-
-        delegations[_delegationIndex]._numerator = 0;
-
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-        vm.expectRevert(InvalidNumeratorZero.selector);
-        tokenProxy.delegate(delegations);
-        vm.stopPrank();
-    }
-
-    function testFuzz_RevertIf_NumeratorSumExceedsDenominator(
-        address _actor,
-        uint256 _amount,
-        uint256 _delegationIndex,
-        uint256 _seed
-    ) public {
-        vm.assume(_actor != address(0));
-        _amount = bound(_amount, 0, type(uint208).max);
-        PartialDelegation[] memory delegations = _createValidPartialDelegation(
-            0,
-            _seed
-        );
-        _delegationIndex = bound(_delegationIndex, 0, delegations.length - 1);
-
-        delegations[_delegationIndex]._numerator = tokenProxy.DENOMINATOR() + 1;
-        uint256 sumOfNumerators;
-        for (uint256 i; i < delegations.length; i++) {
-            sumOfNumerators += delegations[i]._numerator;
-        }
-
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                NumeratorSumExceedsDenominator.selector,
-                sumOfNumerators,
-                tokenProxy.DENOMINATOR()
-            )
-        );
-        tokenProxy.delegate(delegations);
-        vm.stopPrank();
-    }
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    vm.expectRevert(
+      abi.encodeWithSelector(NumeratorSumExceedsDenominator.selector, sumOfNumerators, tokenProxy.DENOMINATOR())
+    );
+    tokenProxy.delegate(delegations);
+    vm.stopPrank();
+  }
 }
 
 contract DelegateLegacy is PartialDelegationTest {
-    function testFuzz_DelegatesSuccessfullyToNonZeroAddress(
-        uint256 _delegatorPrivateKey,
-        address _delegatee,
-        uint256 _delegatorBalance,
-        uint256 _deadline
-    ) public {
-        vm.assume(_delegatee != address(0));
-        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-        address _delegator = vm.addr(_delegatorPrivateKey);
-        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-        _mint(_delegator, _delegatorBalance);
+  function testFuzz_DelegatesSuccessfullyToNonZeroAddress(
+    uint256 _delegatorPrivateKey,
+    address _delegatee,
+    uint256 _delegatorBalance,
+    uint256 _deadline
+  ) public {
+    vm.assume(_delegatee != address(0));
+    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+    address _delegator = vm.addr(_delegatorPrivateKey);
+    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+    _mint(_delegator, _delegatorBalance);
 
-        vm.prank(_delegator);
-        tokenProxy.delegate(_delegatee);
-        assertEq(
-            tokenProxy.delegates(_delegator),
-            _createSingleFullDelegation(_delegatee)
-        );
-        assertEq(tokenProxy.getVotes(_delegatee), _delegatorBalance);
-    }
+    vm.prank(_delegator);
+    tokenProxy.delegate(_delegatee);
+    assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_delegatee));
+    assertEq(tokenProxy.getVotes(_delegatee), _delegatorBalance);
+  }
 
-    function testFuzz_DelegatesSuccessfullyToZeroAddress(
-        uint256 _delegatorPrivateKey,
-        uint256 _delegatorBalance,
-        uint256 _deadline
-    ) public {
-        address _delegatee = address(0);
-        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-        address _delegator = vm.addr(_delegatorPrivateKey);
-        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-        _mint(_delegator, _delegatorBalance);
+  function testFuzz_DelegatesSuccessfullyToZeroAddress(
+    uint256 _delegatorPrivateKey,
+    uint256 _delegatorBalance,
+    uint256 _deadline
+  ) public {
+    address _delegatee = address(0);
+    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+    address _delegator = vm.addr(_delegatorPrivateKey);
+    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+    _mint(_delegator, _delegatorBalance);
 
-        vm.prank(_delegator);
-        tokenProxy.delegate(_delegatee);
-        assertEq(
-            tokenProxy.delegates(_delegator),
-            _createSingleFullDelegation(_delegatee)
-        );
-        assertEq(tokenProxy.getVotes(_delegatee), 0);
-    }
+    vm.prank(_delegator);
+    tokenProxy.delegate(_delegatee);
+    assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_delegatee));
+    assertEq(tokenProxy.getVotes(_delegatee), 0);
+  }
 
-    function testFuzz_RedelegatesSuccessfully(
-        uint256 _delegatorPrivateKey,
-        address _delegatee,
-        address _newDelegatee,
-        uint256 _delegatorBalance,
-        uint256 _deadline
-    ) public {
-        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-        address _delegator = vm.addr(_delegatorPrivateKey);
-        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-        _mint(_delegator, _delegatorBalance);
+  function testFuzz_RedelegatesSuccessfully(
+    uint256 _delegatorPrivateKey,
+    address _delegatee,
+    address _newDelegatee,
+    uint256 _delegatorBalance,
+    uint256 _deadline
+  ) public {
+    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+    address _delegator = vm.addr(_delegatorPrivateKey);
+    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+    _mint(_delegator, _delegatorBalance);
 
-        vm.prank(_delegator);
-        tokenProxy.delegate(_delegatee);
-        assertEq(
-            tokenProxy.delegates(_delegator),
-            _createSingleFullDelegation(_delegatee)
-        );
-        uint256 _expectedVotes = _delegatee == address(0)
-            ? 0
-            : _delegatorBalance;
-        assertEq(tokenProxy.getVotes(_delegatee), _expectedVotes);
+    vm.prank(_delegator);
+    tokenProxy.delegate(_delegatee);
+    assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_delegatee));
+    uint256 _expectedVotes = _delegatee == address(0) ? 0 : _delegatorBalance;
+    assertEq(tokenProxy.getVotes(_delegatee), _expectedVotes);
 
-        vm.prank(_delegator);
-        tokenProxy.delegate(_newDelegatee);
-        assertEq(
-            tokenProxy.delegates(_delegator),
-            _createSingleFullDelegation(_newDelegatee)
-        );
-        _expectedVotes = _newDelegatee == address(0) ? 0 : _delegatorBalance;
-        assertEq(tokenProxy.getVotes(_newDelegatee), _expectedVotes);
-    }
+    vm.prank(_delegator);
+    tokenProxy.delegate(_newDelegatee);
+    assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_newDelegatee));
+    _expectedVotes = _newDelegatee == address(0) ? 0 : _delegatorBalance;
+    assertEq(tokenProxy.getVotes(_newDelegatee), _expectedVotes);
+  }
 
-    function testFuzz_RedelegatesToAPartialDelegationSuccessfully(
-        uint256 _delegatorPrivateKey,
-        address _delegatee,
-        uint256 _delegatorBalance,
-        uint256 _deadline,
-        uint256 _seed
-    ) public {
-        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-        address _delegator = vm.addr(_delegatorPrivateKey);
-        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-        _mint(_delegator, _delegatorBalance);
+  function testFuzz_RedelegatesToAPartialDelegationSuccessfully(
+    uint256 _delegatorPrivateKey,
+    address _delegatee,
+    uint256 _delegatorBalance,
+    uint256 _deadline,
+    uint256 _seed
+  ) public {
+    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+    address _delegator = vm.addr(_delegatorPrivateKey);
+    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+    _mint(_delegator, _delegatorBalance);
 
-        vm.prank(_delegator);
-        tokenProxy.delegate(_delegatee);
-        assertEq(
-            tokenProxy.delegates(_delegator),
-            _createSingleFullDelegation(_delegatee)
-        );
-        uint256 _expectedVotes = _delegatee == address(0)
-            ? 0
-            : _delegatorBalance;
-        assertEq(tokenProxy.getVotes(_delegatee), _expectedVotes);
+    vm.prank(_delegator);
+    tokenProxy.delegate(_delegatee);
+    assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_delegatee));
+    uint256 _expectedVotes = _delegatee == address(0) ? 0 : _delegatorBalance;
+    assertEq(tokenProxy.getVotes(_delegatee), _expectedVotes);
 
-        PartialDelegation[]
-            memory newDelegations = _createValidPartialDelegation(
-                0,
-                uint256(keccak256(abi.encode(_seed)))
-            );
-        vm.prank(_delegator);
-        tokenProxy.delegate(newDelegations);
-        assertEq(tokenProxy.delegates(_delegator), newDelegations);
-        assertCorrectVotes(newDelegations, _delegatorBalance);
-    }
+    PartialDelegation[] memory newDelegations = _createValidPartialDelegation(0, uint256(keccak256(abi.encode(_seed))));
+    vm.prank(_delegator);
+    tokenProxy.delegate(newDelegations);
+    assertEq(tokenProxy.delegates(_delegator), newDelegations);
+    assertCorrectVotes(newDelegations, _delegatorBalance);
+  }
 }
 
 contract DelegateBySig is PartialDelegationTest {
-    using stdStorage for StdStorage;
+  using stdStorage for StdStorage;
 
-    function testFuzz_DelegatesSuccessfullyToNonZeroAddress(
-        address _actor,
-        uint256 _delegatorPrivateKey,
-        address _delegatee,
-        uint256 _delegatorBalance,
-        uint256 _currentNonce,
-        uint256 _deadline
-    ) public {
-        vm.assume(_actor != address(0));
-        vm.assume(_delegatee != address(0));
-        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-        address _delegator = vm.addr(_delegatorPrivateKey);
-        stdstore
-            .target(address(tokenProxy))
-            .sig("nonces(address)")
-            .with_key(_delegator)
-            .checked_write(_currentNonce);
-        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-        _mint(_delegator, _delegatorBalance);
+  function testFuzz_DelegatesSuccessfullyToNonZeroAddress(
+    address _actor,
+    uint256 _delegatorPrivateKey,
+    address _delegatee,
+    uint256 _delegatorBalance,
+    uint256 _currentNonce,
+    uint256 _deadline
+  ) public {
+    vm.assume(_actor != address(0));
+    vm.assume(_delegatee != address(0));
+    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+    address _delegator = vm.addr(_delegatorPrivateKey);
+    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_delegator).checked_write(_currentNonce);
+    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+    _mint(_delegator, _delegatorBalance);
 
-        bytes32 _message = keccak256(
-            abi.encode(
-                tokenProxy.DELEGATION_TYPEHASH(),
-                _delegatee,
-                _currentNonce,
-                _deadline
-            )
-        );
+    bytes32 _message = keccak256(abi.encode(tokenProxy.DELEGATION_TYPEHASH(), _delegatee, _currentNonce, _deadline));
 
-        bytes32 _messageHash = keccak256(
-            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
-        );
-        (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(
-            _delegatorPrivateKey,
-            _messageHash
-        );
-        vm.prank(_actor);
-        tokenProxy.delegateBySig(
-            _delegatee,
-            _currentNonce,
-            _deadline,
-            _v,
-            _r,
-            _s
-        );
-        assertEq(
-            tokenProxy.delegates(_delegator),
-            _createSingleFullDelegation(_delegatee)
-        );
-        assertEq(tokenProxy.getVotes(_delegatee), _delegatorBalance);
+    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
+    (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_delegatorPrivateKey, _messageHash);
+    vm.prank(_actor);
+    tokenProxy.delegateBySig(_delegatee, _currentNonce, _deadline, _v, _r, _s);
+    assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_delegatee));
+    assertEq(tokenProxy.getVotes(_delegatee), _delegatorBalance);
+  }
+
+  function testFuzz_DelegatesSuccessfullyToZeroAddress(
+    address _actor,
+    uint256 _delegatorPrivateKey,
+    uint256 _delegatorBalance,
+    uint256 _currentNonce,
+    uint256 _deadline
+  ) public {
+    vm.assume(_actor != address(0));
+    address _delegatee = address(0);
+    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+    address _delegator = vm.addr(_delegatorPrivateKey);
+    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_delegator).checked_write(_currentNonce);
+    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+    _mint(_delegator, _delegatorBalance);
+
+    bytes32 _message = keccak256(abi.encode(tokenProxy.DELEGATION_TYPEHASH(), address(0), _currentNonce, _deadline));
+
+    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
+    (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_delegatorPrivateKey, _messageHash);
+    vm.prank(_actor);
+    tokenProxy.delegateBySig(_delegatee, _currentNonce, _deadline, _v, _r, _s);
+    assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_delegatee));
+    assertEq(tokenProxy.getVotes(_delegatee), 0);
+  }
+
+  function testFuzz_RevertIf_DelegatesViaERC712SignatureWithExpiredDeadline(
+    address _actor,
+    uint256 _delegatorPrivateKey,
+    address _delegatee,
+    uint256 _delegatorBalance,
+    uint256 _currentNonce,
+    uint256 _currentTimestamp,
+    uint256 _deadline
+  ) public {
+    vm.assume(_actor != address(0));
+    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+    address _delegator = vm.addr(_delegatorPrivateKey);
+    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_delegator).checked_write(_currentNonce);
+    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+    _currentTimestamp = bound(_currentTimestamp, 1, type(uint256).max);
+    vm.warp(_currentTimestamp);
+    _deadline = bound(_deadline, 0, _currentTimestamp - 1);
+    _mint(_delegator, _delegatorBalance);
+
+    bytes32 _message = keccak256(abi.encode(tokenProxy.DELEGATION_TYPEHASH(), _delegatee, _currentNonce, _deadline));
+
+    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
+    (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_delegatorPrivateKey, _messageHash);
+    vm.prank(_actor);
+    vm.expectRevert(abi.encodeWithSelector(VotesExpiredSignature.selector, _deadline));
+    tokenProxy.delegateBySig(_delegatee, _currentNonce, _deadline, _v, _r, _s);
+  }
+
+  function testFuzz_RevertIf_DelegatesViaERC712SignatureWithWrongNonce(
+    address _actor,
+    uint256 _delegatorPrivateKey,
+    address _delegatee,
+    uint256 _delegatorBalance,
+    uint256 _currentNonce,
+    uint256 _suppliedNonce,
+    uint256 _deadline
+  ) public {
+    vm.assume(_actor != address(0));
+    vm.assume(_suppliedNonce != _currentNonce);
+    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+    address _delegator = vm.addr(_delegatorPrivateKey);
+    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_delegator).checked_write(_currentNonce);
+    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+    _mint(_delegator, _delegatorBalance);
+
+    bytes32 _message = keccak256(abi.encode(tokenProxy.DELEGATION_TYPEHASH(), _delegatee, _suppliedNonce, _deadline));
+
+    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
+    (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_delegatorPrivateKey, _messageHash);
+    vm.prank(_actor);
+    vm.expectRevert(abi.encodeWithSelector(InvalidAccountNonce.selector, _delegator, tokenProxy.nonces(_delegator)));
+    tokenProxy.delegateBySig(_delegatee, _suppliedNonce, _deadline, _v, _r, _s);
+  }
+
+  function testFuzz_RevertIf_DelegatesViaInvalidERC712Signature(
+    address _actor,
+    uint256 _delegatorPrivateKey,
+    address _delegatee,
+    uint256 _delegatorBalance,
+    uint256 _currentNonce,
+    uint256 _deadline,
+    uint256 _randomSeed
+  ) public {
+    vm.assume(_actor != address(0));
+    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+    address _delegator = vm.addr(_delegatorPrivateKey);
+    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_delegator).checked_write(_currentNonce);
+    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+    _mint(_delegator, _delegatorBalance);
+
+    bytes32 _message = keccak256(abi.encode(tokenProxy.DELEGATION_TYPEHASH(), _delegatee, _currentNonce, _deadline));
+    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
+
+    // Here we use `_randomSeed` as an arbitrary source of randomness to replace a legit parameter
+    // with an attack-like one.
+    if (_randomSeed % 3 == 0) {
+      _delegatee = address(uint160(uint256(keccak256(abi.encode(_delegatee)))));
+    } else if (_randomSeed % 3 == 1) {
+      _currentNonce = uint256(keccak256(abi.encode(_currentNonce)));
+    }
+    (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_delegatorPrivateKey, _messageHash);
+    if (_randomSeed % 3 == 2) {
+      (_v, _r, _s) = vm.sign(uint256(keccak256(abi.encode(_delegatorPrivateKey))), _messageHash);
     }
 
-    function testFuzz_DelegatesSuccessfullyToZeroAddress(
-        address _actor,
-        uint256 _delegatorPrivateKey,
-        uint256 _delegatorBalance,
-        uint256 _currentNonce,
-        uint256 _deadline
-    ) public {
-        vm.assume(_actor != address(0));
-        address _delegatee = address(0);
-        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-        address _delegator = vm.addr(_delegatorPrivateKey);
-        stdstore
-            .target(address(tokenProxy))
-            .sig("nonces(address)")
-            .with_key(_delegator)
-            .checked_write(_currentNonce);
-        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-        _mint(_delegator, _delegatorBalance);
-
-        bytes32 _message = keccak256(
-            abi.encode(
-                tokenProxy.DELEGATION_TYPEHASH(),
-                address(0),
-                _currentNonce,
-                _deadline
-            )
-        );
-
-        bytes32 _messageHash = keccak256(
-            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
-        );
-        (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(
-            _delegatorPrivateKey,
-            _messageHash
-        );
-        vm.prank(_actor);
-        tokenProxy.delegateBySig(
-            _delegatee,
-            _currentNonce,
-            _deadline,
-            _v,
-            _r,
-            _s
-        );
-        assertEq(
-            tokenProxy.delegates(_delegator),
-            _createSingleFullDelegation(_delegatee)
-        );
-        assertEq(tokenProxy.getVotes(_delegatee), 0);
-    }
-
-    function testFuzz_RevertIf_DelegatesViaERC712SignatureWithExpiredDeadline(
-        address _actor,
-        uint256 _delegatorPrivateKey,
-        address _delegatee,
-        uint256 _delegatorBalance,
-        uint256 _currentNonce,
-        uint256 _currentTimestamp,
-        uint256 _deadline
-    ) public {
-        vm.assume(_actor != address(0));
-        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-        address _delegator = vm.addr(_delegatorPrivateKey);
-        stdstore
-            .target(address(tokenProxy))
-            .sig("nonces(address)")
-            .with_key(_delegator)
-            .checked_write(_currentNonce);
-        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-        _currentTimestamp = bound(_currentTimestamp, 1, type(uint256).max);
-        vm.warp(_currentTimestamp);
-        _deadline = bound(_deadline, 0, _currentTimestamp - 1);
-        _mint(_delegator, _delegatorBalance);
-
-        bytes32 _message = keccak256(
-            abi.encode(
-                tokenProxy.DELEGATION_TYPEHASH(),
-                _delegatee,
-                _currentNonce,
-                _deadline
-            )
-        );
-
-        bytes32 _messageHash = keccak256(
-            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
-        );
-        (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(
-            _delegatorPrivateKey,
-            _messageHash
-        );
-        vm.prank(_actor);
-        vm.expectRevert(
-            abi.encodeWithSelector(VotesExpiredSignature.selector, _deadline)
-        );
-        tokenProxy.delegateBySig(
-            _delegatee,
-            _currentNonce,
-            _deadline,
-            _v,
-            _r,
-            _s
-        );
-    }
-
-    function testFuzz_RevertIf_DelegatesViaERC712SignatureWithWrongNonce(
-        address _actor,
-        uint256 _delegatorPrivateKey,
-        address _delegatee,
-        uint256 _delegatorBalance,
-        uint256 _currentNonce,
-        uint256 _suppliedNonce,
-        uint256 _deadline
-    ) public {
-        vm.assume(_actor != address(0));
-        vm.assume(_suppliedNonce != _currentNonce);
-        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-        address _delegator = vm.addr(_delegatorPrivateKey);
-        stdstore
-            .target(address(tokenProxy))
-            .sig("nonces(address)")
-            .with_key(_delegator)
-            .checked_write(_currentNonce);
-        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-        _mint(_delegator, _delegatorBalance);
-
-        bytes32 _message = keccak256(
-            abi.encode(
-                tokenProxy.DELEGATION_TYPEHASH(),
-                _delegatee,
-                _suppliedNonce,
-                _deadline
-            )
-        );
-
-        bytes32 _messageHash = keccak256(
-            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
-        );
-        (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(
-            _delegatorPrivateKey,
-            _messageHash
-        );
-        vm.prank(_actor);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                InvalidAccountNonce.selector,
-                _delegator,
-                tokenProxy.nonces(_delegator)
-            )
-        );
-        tokenProxy.delegateBySig(
-            _delegatee,
-            _suppliedNonce,
-            _deadline,
-            _v,
-            _r,
-            _s
-        );
-    }
-
-    function testFuzz_RevertIf_DelegatesViaInvalidERC712Signature(
-        address _actor,
-        uint256 _delegatorPrivateKey,
-        address _delegatee,
-        uint256 _delegatorBalance,
-        uint256 _currentNonce,
-        uint256 _deadline,
-        uint256 _randomSeed
-    ) public {
-        vm.assume(_actor != address(0));
-        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-        address _delegator = vm.addr(_delegatorPrivateKey);
-        stdstore
-            .target(address(tokenProxy))
-            .sig("nonces(address)")
-            .with_key(_delegator)
-            .checked_write(_currentNonce);
-        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-        _mint(_delegator, _delegatorBalance);
-
-        bytes32 _message = keccak256(
-            abi.encode(
-                tokenProxy.DELEGATION_TYPEHASH(),
-                _delegatee,
-                _currentNonce,
-                _deadline
-            )
-        );
-        bytes32 _messageHash = keccak256(
-            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
-        );
-
-        // Here we use `_randomSeed` as an arbitrary source of randomness to replace a legit parameter
-        // with an attack-like one.
-        if (_randomSeed % 3 == 0) {
-            _delegatee = address(
-                uint160(uint256(keccak256(abi.encode(_delegatee))))
-            );
-        } else if (_randomSeed % 3 == 1) {
-            _currentNonce = uint256(keccak256(abi.encode(_currentNonce)));
-        }
-        (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(
-            _delegatorPrivateKey,
-            _messageHash
-        );
-        if (_randomSeed % 3 == 2) {
-            (_v, _r, _s) = vm.sign(
-                uint256(keccak256(abi.encode(_delegatorPrivateKey))),
-                _messageHash
-            );
-        }
-
-        vm.prank(_actor);
-        try
-            tokenProxy.delegateBySig(
-                _delegatee,
-                _currentNonce,
-                _deadline,
-                _v,
-                _r,
-                _s
-            )
-        {} catch {}
-        assertEq(tokenProxy.delegates(_delegator), new PartialDelegation[](0));
-    }
+    vm.prank(_actor);
+    try tokenProxy.delegateBySig(_delegatee, _currentNonce, _deadline, _v, _r, _s) {} catch {}
+    assertEq(tokenProxy.delegates(_delegator), new PartialDelegation[](0));
+  }
 }
 
 contract DelegatePartiallyOnBehalf is PartialDelegationTest {
-    using stdStorage for StdStorage;
+  using stdStorage for StdStorage;
 
-    function testFuzz_DelegatesSuccessfullyViaERC712Signer(
-        address _actor,
-        uint256 _delegatorPrivateKey,
-        uint256 _delegationSeed,
-        uint256 _delegatorBalance,
-        uint256 _currentNonce,
-        uint256 _deadline
-    ) public {
-        vm.assume(_actor != address(0));
-        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-        address _delegator = vm.addr(_delegatorPrivateKey);
-        stdstore
-            .target(address(tokenProxy))
-            .sig("nonces(address)")
-            .with_key(_delegator)
-            .checked_write(_currentNonce);
-        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-        _mint(_delegator, _delegatorBalance);
+  function testFuzz_DelegatesSuccessfullyViaERC712Signer(
+    address _actor,
+    uint256 _delegatorPrivateKey,
+    uint256 _delegationSeed,
+    uint256 _delegatorBalance,
+    uint256 _currentNonce,
+    uint256 _deadline
+  ) public {
+    vm.assume(_actor != address(0));
+    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+    address _delegator = vm.addr(_delegatorPrivateKey);
+    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_delegator).checked_write(_currentNonce);
+    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+    _mint(_delegator, _delegatorBalance);
 
-        PartialDelegation[] memory _delegations = _createValidPartialDelegation(
-            0,
-            _delegationSeed
-        );
+    PartialDelegation[] memory _delegations = _createValidPartialDelegation(0, _delegationSeed);
 
-        bytes32[] memory _payload = new bytes32[](_delegations.length);
-        for (uint256 i; i < _delegations.length; i++) {
-            _payload[i] = _hash(_delegations[i]);
-        }
-
-        bytes32 _message = keccak256(
-            abi.encode(
-                tokenProxy.PARTIAL_DELEGATION_ON_BEHALF_TYPEHASH(),
-                _delegator,
-                keccak256(abi.encodePacked(_payload)),
-                _currentNonce,
-                _deadline
-            )
-        );
-
-        bytes32 _messageHash = keccak256(
-            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
-        );
-        bytes memory _signature = _sign(_delegatorPrivateKey, _messageHash);
-        vm.prank(_actor);
-        tokenProxy.delegatePartiallyOnBehalf(
-            _delegator,
-            _delegations,
-            _currentNonce,
-            _deadline,
-            _signature
-        );
-        assertEq(tokenProxy.delegates(_delegator), _delegations);
+    bytes32[] memory _payload = new bytes32[](_delegations.length);
+    for (uint256 i; i < _delegations.length; i++) {
+      _payload[i] = _hash(_delegations[i]);
     }
 
-    function testFuzz_DelegatesSuccessfullyViaERC1271Signer(
-        address _actor,
-        uint256 _delegationSeed,
-        uint256 _delegatorBalance,
-        uint256 _currentNonce,
-        uint256 _deadline,
-        bytes memory _signature
-    ) public {
-        vm.assume(_actor != address(0));
-        MockERC1271Signer _erc1271Signer = new MockERC1271Signer();
-        _erc1271Signer.setResponse__isValidSignature(true);
-        address _delegator = address(_erc1271Signer);
-        stdstore
-            .target(address(tokenProxy))
-            .sig("nonces(address)")
-            .with_key(address(_delegator))
-            .checked_write(_currentNonce);
-        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-        _mint(_delegator, _delegatorBalance);
+    bytes32 _message = keccak256(
+      abi.encode(
+        tokenProxy.PARTIAL_DELEGATION_ON_BEHALF_TYPEHASH(),
+        _delegator,
+        keccak256(abi.encodePacked(_payload)),
+        _currentNonce,
+        _deadline
+      )
+    );
 
-        PartialDelegation[] memory _delegations = _createValidPartialDelegation(
-            0,
-            _delegationSeed
-        );
+    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
+    bytes memory _signature = _sign(_delegatorPrivateKey, _messageHash);
+    vm.prank(_actor);
+    tokenProxy.delegatePartiallyOnBehalf(_delegator, _delegations, _currentNonce, _deadline, _signature);
+    assertEq(tokenProxy.delegates(_delegator), _delegations);
+  }
 
-        bytes32[] memory _payload = new bytes32[](_delegations.length);
-        for (uint256 i; i < _delegations.length; i++) {
-            _payload[i] = _hash(_delegations[i]);
-        }
+  function testFuzz_DelegatesSuccessfullyViaERC1271Signer(
+    address _actor,
+    uint256 _delegationSeed,
+    uint256 _delegatorBalance,
+    uint256 _currentNonce,
+    uint256 _deadline,
+    bytes memory _signature
+  ) public {
+    vm.assume(_actor != address(0));
+    MockERC1271Signer _erc1271Signer = new MockERC1271Signer();
+    _erc1271Signer.setResponse__isValidSignature(true);
+    address _delegator = address(_erc1271Signer);
+    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(address(_delegator)).checked_write(
+      _currentNonce
+    );
+    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+    _mint(_delegator, _delegatorBalance);
 
-        vm.prank(_actor);
-        tokenProxy.delegatePartiallyOnBehalf(
-            _delegator,
-            _delegations,
-            _currentNonce,
-            _deadline,
-            _signature
-        );
-        assertEq(tokenProxy.delegates(_delegator), _delegations);
+    PartialDelegation[] memory _delegations = _createValidPartialDelegation(0, _delegationSeed);
+
+    bytes32[] memory _payload = new bytes32[](_delegations.length);
+    for (uint256 i; i < _delegations.length; i++) {
+      _payload[i] = _hash(_delegations[i]);
     }
 
-    function testFuzz_RevertIf_DelegatesViaERC712SignerWithWrongNonce(
-        address _actor,
-        uint256 _delegatorPrivateKey,
-        uint256 _delegationSeed,
-        uint256 _delegatorBalance,
-        uint256 _currentNonce,
-        uint256 _suppliedNonce,
-        uint256 _deadline
-    ) public {
-        vm.assume(_actor != address(0));
-        vm.assume(_suppliedNonce != _currentNonce);
-        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-        address _delegator = vm.addr(_delegatorPrivateKey);
-        stdstore
-            .target(address(tokenProxy))
-            .sig("nonces(address)")
-            .with_key(_delegator)
-            .checked_write(_currentNonce);
-        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-        _mint(_delegator, _delegatorBalance);
+    vm.prank(_actor);
+    tokenProxy.delegatePartiallyOnBehalf(_delegator, _delegations, _currentNonce, _deadline, _signature);
+    assertEq(tokenProxy.delegates(_delegator), _delegations);
+  }
 
-        PartialDelegation[] memory _delegations = _createValidPartialDelegation(
-            0,
-            _delegationSeed
-        );
+  function testFuzz_RevertIf_DelegatesViaERC712SignerWithWrongNonce(
+    address _actor,
+    uint256 _delegatorPrivateKey,
+    uint256 _delegationSeed,
+    uint256 _delegatorBalance,
+    uint256 _currentNonce,
+    uint256 _suppliedNonce,
+    uint256 _deadline
+  ) public {
+    vm.assume(_actor != address(0));
+    vm.assume(_suppliedNonce != _currentNonce);
+    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+    address _delegator = vm.addr(_delegatorPrivateKey);
+    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_delegator).checked_write(_currentNonce);
+    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+    _mint(_delegator, _delegatorBalance);
 
-        bytes32[] memory _payload = new bytes32[](_delegations.length);
-        for (uint256 i; i < _delegations.length; i++) {
-            _payload[i] = _hash(_delegations[i]);
-        }
+    PartialDelegation[] memory _delegations = _createValidPartialDelegation(0, _delegationSeed);
 
-        bytes32 _message = keccak256(
-            abi.encode(
-                tokenProxy.PARTIAL_DELEGATION_ON_BEHALF_TYPEHASH(),
-                _delegator,
-                keccak256(abi.encodePacked(_payload)),
-                _suppliedNonce,
-                _deadline
-            )
-        );
-
-        bytes32 _messageHash = keccak256(
-            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
-        );
-        bytes memory _signature = _sign(_delegatorPrivateKey, _messageHash);
-        vm.prank(_actor);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                InvalidAccountNonce.selector,
-                _delegator,
-                tokenProxy.nonces(_delegator)
-            )
-        );
-        tokenProxy.delegatePartiallyOnBehalf(
-            _delegator,
-            _delegations,
-            _suppliedNonce,
-            _deadline,
-            _signature
-        );
+    bytes32[] memory _payload = new bytes32[](_delegations.length);
+    for (uint256 i; i < _delegations.length; i++) {
+      _payload[i] = _hash(_delegations[i]);
     }
 
-    function testFuzz_RevertIf_DelegatesViaERC712SignatureWithExpiredDeadline(
-        address _actor,
-        uint256 _delegatorPrivateKey,
-        uint256 _delegationSeed,
-        uint256 _delegatorBalance,
-        uint256 _currentNonce,
-        uint256 _currentTimeStamp,
-        uint256 _deadline
-    ) public {
-        vm.assume(_actor != address(0));
-        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-        address _delegator = vm.addr(_delegatorPrivateKey);
-        stdstore
-            .target(address(tokenProxy))
-            .sig("nonces(address)")
-            .with_key(_delegator)
-            .checked_write(_currentNonce);
-        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-        _currentTimeStamp = bound(_currentTimeStamp, 1, type(uint256).max);
-        vm.warp(_currentTimeStamp);
-        _deadline = bound(_deadline, 0, _currentTimeStamp - 1);
+    bytes32 _message = keccak256(
+      abi.encode(
+        tokenProxy.PARTIAL_DELEGATION_ON_BEHALF_TYPEHASH(),
+        _delegator,
+        keccak256(abi.encodePacked(_payload)),
+        _suppliedNonce,
+        _deadline
+      )
+    );
 
-        _mint(_delegator, _delegatorBalance);
+    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
+    bytes memory _signature = _sign(_delegatorPrivateKey, _messageHash);
+    vm.prank(_actor);
+    vm.expectRevert(abi.encodeWithSelector(InvalidAccountNonce.selector, _delegator, tokenProxy.nonces(_delegator)));
+    tokenProxy.delegatePartiallyOnBehalf(_delegator, _delegations, _suppliedNonce, _deadline, _signature);
+  }
 
-        PartialDelegation[] memory _delegations = _createValidPartialDelegation(
-            0,
-            _delegationSeed
-        );
+  function testFuzz_RevertIf_DelegatesViaERC712SignatureWithExpiredDeadline(
+    address _actor,
+    uint256 _delegatorPrivateKey,
+    uint256 _delegationSeed,
+    uint256 _delegatorBalance,
+    uint256 _currentNonce,
+    uint256 _currentTimeStamp,
+    uint256 _deadline
+  ) public {
+    vm.assume(_actor != address(0));
+    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+    address _delegator = vm.addr(_delegatorPrivateKey);
+    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_delegator).checked_write(_currentNonce);
+    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+    _currentTimeStamp = bound(_currentTimeStamp, 1, type(uint256).max);
+    vm.warp(_currentTimeStamp);
+    _deadline = bound(_deadline, 0, _currentTimeStamp - 1);
 
-        bytes32[] memory _payload = new bytes32[](_delegations.length);
-        for (uint256 i; i < _delegations.length; i++) {
-            _payload[i] = _hash(_delegations[i]);
-        }
+    _mint(_delegator, _delegatorBalance);
 
-        bytes32 _message = keccak256(
-            abi.encode(
-                tokenProxy.PARTIAL_DELEGATION_ON_BEHALF_TYPEHASH(),
-                _delegator,
-                keccak256(abi.encodePacked(_payload)),
-                _currentNonce,
-                _deadline
-            )
-        );
+    PartialDelegation[] memory _delegations = _createValidPartialDelegation(0, _delegationSeed);
 
-        bytes32 _messageHash = keccak256(
-            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
-        );
-        bytes memory _signature = _sign(_delegatorPrivateKey, _messageHash);
-        vm.prank(_actor);
-        vm.expectRevert(
-            abi.encodeWithSelector(VotesExpiredSignature.selector, _deadline)
-        );
-        tokenProxy.delegatePartiallyOnBehalf(
-            _delegator,
-            _delegations,
-            _currentNonce,
-            _deadline,
-            _signature
-        );
+    bytes32[] memory _payload = new bytes32[](_delegations.length);
+    for (uint256 i; i < _delegations.length; i++) {
+      _payload[i] = _hash(_delegations[i]);
     }
 
-    function testFuzz_RevertIf_DelegatesViaInvalidERC712Signature(
-        address _actor,
-        uint256 _delegatorPrivateKey,
-        uint256 _delegationSeed,
-        uint256 _delegatorBalance,
-        uint256 _currentNonce,
-        uint256 _deadline,
-        uint256 _randomSeed
-    ) public {
-        vm.assume(_actor != address(0));
-        _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
-        address _delegator = vm.addr(_delegatorPrivateKey);
-        stdstore
-            .target(address(tokenProxy))
-            .sig("nonces(address)")
-            .with_key(_delegator)
-            .checked_write(_currentNonce);
-        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-        _deadline = bound(_deadline, 1, type(uint256).max);
-        vm.warp(_deadline);
-        _deadline = bound(_deadline, 0, block.timestamp - 1);
+    bytes32 _message = keccak256(
+      abi.encode(
+        tokenProxy.PARTIAL_DELEGATION_ON_BEHALF_TYPEHASH(),
+        _delegator,
+        keccak256(abi.encodePacked(_payload)),
+        _currentNonce,
+        _deadline
+      )
+    );
 
-        _mint(_delegator, _delegatorBalance);
+    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
+    bytes memory _signature = _sign(_delegatorPrivateKey, _messageHash);
+    vm.prank(_actor);
+    vm.expectRevert(abi.encodeWithSelector(VotesExpiredSignature.selector, _deadline));
+    tokenProxy.delegatePartiallyOnBehalf(_delegator, _delegations, _currentNonce, _deadline, _signature);
+  }
 
-        PartialDelegation[] memory _delegations = _createValidPartialDelegation(
-            0,
-            _delegationSeed
-        );
+  function testFuzz_RevertIf_DelegatesViaInvalidERC712Signature(
+    address _actor,
+    uint256 _delegatorPrivateKey,
+    uint256 _delegationSeed,
+    uint256 _delegatorBalance,
+    uint256 _currentNonce,
+    uint256 _deadline,
+    uint256 _randomSeed
+  ) public {
+    vm.assume(_actor != address(0));
+    _delegatorPrivateKey = bound(_delegatorPrivateKey, 1, 100e18);
+    address _delegator = vm.addr(_delegatorPrivateKey);
+    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_delegator).checked_write(_currentNonce);
+    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+    _deadline = bound(_deadline, 1, type(uint256).max);
+    vm.warp(_deadline);
+    _deadline = bound(_deadline, 0, block.timestamp - 1);
 
-        bytes32[] memory _payload = new bytes32[](_delegations.length);
-        for (uint256 i; i < _delegations.length; i++) {
-            _payload[i] = _hash(_delegations[i]);
-        }
+    _mint(_delegator, _delegatorBalance);
 
-        bytes32 _message = keccak256(
-            abi.encode(
-                tokenProxy.PARTIAL_DELEGATION_ON_BEHALF_TYPEHASH(),
-                _delegator,
-                keccak256(abi.encodePacked(_payload)),
-                _currentNonce,
-                _deadline
-            )
-        );
+    PartialDelegation[] memory _delegations = _createValidPartialDelegation(0, _delegationSeed);
 
-        bytes32 _messageHash = keccak256(
-            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
-        );
-
-        // Here we use `_randomSeed` as an arbitrary source of randomness to replace a legit parameter
-        // with an attack-like one.
-        if (_randomSeed % 5 == 0) {
-            _delegationSeed = uint256(keccak256(abi.encode(_delegationSeed)));
-        } else if (_randomSeed % 5 == 1) {
-            _delegator = address(
-                uint160(uint256(keccak256(abi.encode(_delegator))))
-            );
-        } else if (_randomSeed % 5 == 2) {
-            _currentNonce = uint256(keccak256(abi.encode(_currentNonce)));
-        } else if (_randomSeed % 5 == 3) {
-            _deadline = uint256(keccak256(abi.encode(_deadline)));
-        }
-
-        bytes memory _signature = _sign(_delegatorPrivateKey, _messageHash);
-        if (_randomSeed % 5 == 4) {
-            _signature = _modifySignature(_signature, _randomSeed);
-        }
-        vm.prank(_actor);
-        vm.expectRevert();
-        tokenProxy.delegatePartiallyOnBehalf(
-            _delegator,
-            _delegations,
-            _currentNonce,
-            _deadline,
-            _signature
-        );
+    bytes32[] memory _payload = new bytes32[](_delegations.length);
+    for (uint256 i; i < _delegations.length; i++) {
+      _payload[i] = _hash(_delegations[i]);
     }
 
-    function testFuzz_RevertIf_TheERC1271SignatureIsNotValid(
-        address _actor,
-        uint256 _delegationSeed,
-        uint256 _delegatorBalance,
-        uint256 _currentNonce,
-        uint256 _deadline,
-        bytes memory _signature
-    ) public {
-        vm.assume(_actor != address(0));
-        MockERC1271Signer _erc1271Signer = new MockERC1271Signer();
-        _erc1271Signer.setResponse__isValidSignature(false);
-        address _delegator = address(_erc1271Signer);
-        stdstore
-            .target(address(tokenProxy))
-            .sig("nonces(address)")
-            .with_key(address(_delegator))
-            .checked_write(_currentNonce);
-        _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
-        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-        _mint(_delegator, _delegatorBalance);
+    bytes32 _message = keccak256(
+      abi.encode(
+        tokenProxy.PARTIAL_DELEGATION_ON_BEHALF_TYPEHASH(),
+        _delegator,
+        keccak256(abi.encodePacked(_payload)),
+        _currentNonce,
+        _deadline
+      )
+    );
 
-        PartialDelegation[] memory _delegations = _createValidPartialDelegation(
-            0,
-            _delegationSeed
-        );
+    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
 
-        bytes32[] memory _payload = new bytes32[](_delegations.length);
-        for (uint256 i; i < _delegations.length; i++) {
-            _payload[i] = _hash(_delegations[i]);
-        }
-
-        vm.prank(_actor);
-        vm.expectRevert(InvalidSignature.selector);
-        tokenProxy.delegatePartiallyOnBehalf(
-            _delegator,
-            _delegations,
-            _currentNonce,
-            _deadline,
-            _signature
-        );
+    // Here we use `_randomSeed` as an arbitrary source of randomness to replace a legit parameter
+    // with an attack-like one.
+    if (_randomSeed % 5 == 0) {
+      _delegationSeed = uint256(keccak256(abi.encode(_delegationSeed)));
+    } else if (_randomSeed % 5 == 1) {
+      _delegator = address(uint160(uint256(keccak256(abi.encode(_delegator)))));
+    } else if (_randomSeed % 5 == 2) {
+      _currentNonce = uint256(keccak256(abi.encode(_currentNonce)));
+    } else if (_randomSeed % 5 == 3) {
+      _deadline = uint256(keccak256(abi.encode(_deadline)));
     }
 
-    function _modifySignature(
-        bytes memory _signature,
-        uint256 _index
-    ) internal pure returns (bytes memory) {
-        _index = bound(_index, 0, _signature.length - 1);
-        // zero out the byte at the given index, or set it to 1 if it's already zero
-        if (_signature[_index] == 0) {
-            _signature[_index] = bytes1(uint8(1));
-        } else {
-            _signature[_index] = bytes1(uint8(0));
-        }
-        return _signature;
+    bytes memory _signature = _sign(_delegatorPrivateKey, _messageHash);
+    if (_randomSeed % 5 == 4) {
+      _signature = _modifySignature(_signature, _randomSeed);
     }
+    vm.prank(_actor);
+    vm.expectRevert();
+    tokenProxy.delegatePartiallyOnBehalf(_delegator, _delegations, _currentNonce, _deadline, _signature);
+  }
+
+  function testFuzz_RevertIf_TheERC1271SignatureIsNotValid(
+    address _actor,
+    uint256 _delegationSeed,
+    uint256 _delegatorBalance,
+    uint256 _currentNonce,
+    uint256 _deadline,
+    bytes memory _signature
+  ) public {
+    vm.assume(_actor != address(0));
+    MockERC1271Signer _erc1271Signer = new MockERC1271Signer();
+    _erc1271Signer.setResponse__isValidSignature(false);
+    address _delegator = address(_erc1271Signer);
+    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(address(_delegator)).checked_write(
+      _currentNonce
+    );
+    _delegatorBalance = bound(_delegatorBalance, 0, type(uint208).max);
+    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+    _mint(_delegator, _delegatorBalance);
+
+    PartialDelegation[] memory _delegations = _createValidPartialDelegation(0, _delegationSeed);
+
+    bytes32[] memory _payload = new bytes32[](_delegations.length);
+    for (uint256 i; i < _delegations.length; i++) {
+      _payload[i] = _hash(_delegations[i]);
+    }
+
+    vm.prank(_actor);
+    vm.expectRevert(InvalidSignature.selector);
+    tokenProxy.delegatePartiallyOnBehalf(_delegator, _delegations, _currentNonce, _deadline, _signature);
+  }
+
+  function _modifySignature(bytes memory _signature, uint256 _index) internal pure returns (bytes memory) {
+    _index = bound(_index, 0, _signature.length - 1);
+    // zero out the byte at the given index, or set it to 1 if it's already zero
+    if (_signature[_index] == 0) {
+      _signature[_index] = bytes1(uint8(1));
+    } else {
+      _signature[_index] = bytes1(uint8(0));
+    }
+    return _signature;
+  }
 }
 
 contract InvalidateNonce is PartialDelegationTest {
-    using stdStorage for StdStorage;
+  using stdStorage for StdStorage;
 
-    function testFuzz_SucessfullyIncrementsTheNonceOfTheSender(
-        address _caller,
-        uint256 _initialNonce
-    ) public {
-        vm.assume(_caller != address(0));
-        vm.assume(_initialNonce != type(uint256).max);
+  function testFuzz_SucessfullyIncrementsTheNonceOfTheSender(address _caller, uint256 _initialNonce) public {
+    vm.assume(_caller != address(0));
+    vm.assume(_initialNonce != type(uint256).max);
 
-        stdstore
-            .target(address(tokenProxy))
-            .sig("nonces(address)")
-            .with_key(_caller)
-            .checked_write(_initialNonce);
+    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_caller).checked_write(_initialNonce);
 
-        vm.prank(_caller);
-        tokenProxy.invalidateNonce();
+    vm.prank(_caller);
+    tokenProxy.invalidateNonce();
 
-        uint256 currentNonce = tokenProxy.nonces(_caller);
+    uint256 currentNonce = tokenProxy.nonces(_caller);
 
-        assertEq(currentNonce, _initialNonce + 1, "Current nonce is incorrect");
-    }
+    assertEq(currentNonce, _initialNonce + 1, "Current nonce is incorrect");
+  }
 
-    function testFuzz_IncreasesTheNonceByTwoWhenCalledTwice(
-        address _caller,
-        uint256 _initialNonce
-    ) public {
-        vm.assume(_caller != address(0));
-        _initialNonce = bound(_initialNonce, 0, type(uint256).max - 2);
+  function testFuzz_IncreasesTheNonceByTwoWhenCalledTwice(address _caller, uint256 _initialNonce) public {
+    vm.assume(_caller != address(0));
+    _initialNonce = bound(_initialNonce, 0, type(uint256).max - 2);
 
-        stdstore
-            .target(address(tokenProxy))
-            .sig("nonces(address)")
-            .with_key(_caller)
-            .checked_write(_initialNonce);
+    stdstore.target(address(tokenProxy)).sig("nonces(address)").with_key(_caller).checked_write(_initialNonce);
 
-        vm.prank(_caller);
-        tokenProxy.invalidateNonce();
+    vm.prank(_caller);
+    tokenProxy.invalidateNonce();
 
-        vm.prank(_caller);
-        tokenProxy.invalidateNonce();
+    vm.prank(_caller);
+    tokenProxy.invalidateNonce();
 
-        uint256 currentNonce = tokenProxy.nonces(_caller);
+    uint256 currentNonce = tokenProxy.nonces(_caller);
 
-        assertEq(currentNonce, _initialNonce + 2, "Current nonce is incorrect");
-    }
+    assertEq(currentNonce, _initialNonce + 2, "Current nonce is incorrect");
+  }
 }
 
 contract Transfer is PartialDelegationTest {
-    function testFuzz_MovesVotesFromOneDelegateeSetToAnother(
-        address _from,
-        address _to,
-        uint256 _amount,
-        uint256 _toExistingBalance
-    ) public {
-        vm.assume(_from != address(0));
-        vm.assume(_to != address(0));
-        vm.assume(_from != _to);
-        _amount = bound(_amount, 0, type(uint208).max);
-        _toExistingBalance = bound(
-            _toExistingBalance,
-            0,
-            type(uint208).max - _amount
-        );
-        PartialDelegation[]
-            memory _fromDelegations = _createValidPartialDelegation(
-                0,
-                uint256(keccak256(abi.encode(_from)))
-            );
-        PartialDelegation[]
-            memory _toDelegations = _createValidPartialDelegation(
-                0,
-                uint256(keccak256(abi.encode(_to)))
-            );
-        vm.startPrank(_to);
-        tokenProxy.mint(_toExistingBalance);
-        tokenProxy.delegate(_toDelegations);
-        vm.stopPrank();
-        vm.startPrank(_from);
-        tokenProxy.mint(_amount);
-        tokenProxy.delegate(_fromDelegations);
-        tokenProxy.transfer(_to, _amount);
-        vm.stopPrank();
+  function testFuzz_MovesVotesFromOneDelegateeSetToAnother(
+    address _from,
+    address _to,
+    uint256 _amount,
+    uint256 _toExistingBalance
+  ) public {
+    vm.assume(_from != address(0));
+    vm.assume(_to != address(0));
+    vm.assume(_from != _to);
+    _amount = bound(_amount, 0, type(uint208).max);
+    _toExistingBalance = bound(_toExistingBalance, 0, type(uint208).max - _amount);
+    PartialDelegation[] memory _fromDelegations =
+      _createValidPartialDelegation(0, uint256(keccak256(abi.encode(_from))));
+    PartialDelegation[] memory _toDelegations = _createValidPartialDelegation(0, uint256(keccak256(abi.encode(_to))));
+    vm.startPrank(_to);
+    tokenProxy.mint(_toExistingBalance);
+    tokenProxy.delegate(_toDelegations);
+    vm.stopPrank();
+    vm.startPrank(_from);
+    tokenProxy.mint(_amount);
+    tokenProxy.delegate(_fromDelegations);
+    tokenProxy.transfer(_to, _amount);
+    vm.stopPrank();
 
-        // check that voting power has been reduced on `from` side by proper amount
-        uint256 _fromTotal = 0;
-        for (uint256 i = 0; i < _fromDelegations.length; i++) {
-            assertEq(tokenProxy.getVotes(_fromDelegations[i]._delegatee), 0);
-            _fromTotal += tokenProxy.getVotes(_fromDelegations[i]._delegatee);
-        }
-        assertEq(_fromTotal, 0, "`from` address total votes mismatch");
-        // check that voting power has been augmented on `to` side by proper amount
-        assertCorrectVotes(_toDelegations, _toExistingBalance + _amount);
-        // check that the asset balance successfully updated
-        assertEq(tokenProxy.balanceOf(_from), 0, "nonzero `from` balance");
-        assertEq(
-            tokenProxy.balanceOf(_to),
-            _toExistingBalance + _amount,
-            "`to` balance mismatch"
-        );
-        assertEq(
-            tokenProxy.totalSupply(),
-            _toExistingBalance + _amount,
-            "total supply mismatch"
-        );
+    // check that voting power has been reduced on `from` side by proper amount
+    uint256 _fromTotal = 0;
+    for (uint256 i = 0; i < _fromDelegations.length; i++) {
+      assertEq(tokenProxy.getVotes(_fromDelegations[i]._delegatee), 0);
+      _fromTotal += tokenProxy.getVotes(_fromDelegations[i]._delegatee);
     }
+    assertEq(_fromTotal, 0, "`from` address total votes mismatch");
+    // check that voting power has been augmented on `to` side by proper amount
+    assertCorrectVotes(_toDelegations, _toExistingBalance + _amount);
+    // check that the asset balance successfully updated
+    assertEq(tokenProxy.balanceOf(_from), 0, "nonzero `from` balance");
+    assertEq(tokenProxy.balanceOf(_to), _toExistingBalance + _amount, "`to` balance mismatch");
+    assertEq(tokenProxy.totalSupply(), _toExistingBalance + _amount, "total supply mismatch");
+  }
 
-    function testFuzz_EmitsDelegateVotesChangedEventsWhenVotesMoveFromOneDelegateeSetToAnother(
-        address _from,
-        address _to,
-        uint256 _amount,
-        uint256 _toExistingBalance
-    ) public {
-        vm.assume(_from != address(0));
-        vm.assume(_to != address(0));
-        vm.assume(_from != _to);
-        _amount = bound(_amount, 1, type(uint208).max);
-        _toExistingBalance = bound(
-            _toExistingBalance,
-            0,
-            type(uint208).max - _amount
-        );
-        PartialDelegation[]
-            memory _fromDelegations = _createValidPartialDelegation(
-                0,
-                uint256(keccak256(abi.encode(_from)))
-            );
-        PartialDelegation[]
-            memory _toDelegations = _createValidPartialDelegation(
-                0,
-                uint256(keccak256(abi.encode(_to)))
-            );
-        vm.startPrank(_to);
-        tokenProxy.mint(_toExistingBalance);
-        tokenProxy.delegate(_toDelegations);
-        vm.stopPrank();
-        vm.startPrank(_from);
-        tokenProxy.mint(_amount);
-        tokenProxy.delegate(_fromDelegations);
+  function testFuzz_EmitsDelegateVotesChangedEventsWhenVotesMoveFromOneDelegateeSetToAnother(
+    address _from,
+    address _to,
+    uint256 _amount,
+    uint256 _toExistingBalance
+  ) public {
+    vm.assume(_from != address(0));
+    vm.assume(_to != address(0));
+    vm.assume(_from != _to);
+    _amount = bound(_amount, 1, type(uint208).max);
+    _toExistingBalance = bound(_toExistingBalance, 0, type(uint208).max - _amount);
+    PartialDelegation[] memory _fromDelegations =
+      _createValidPartialDelegation(0, uint256(keccak256(abi.encode(_from))));
+    PartialDelegation[] memory _toDelegations = _createValidPartialDelegation(0, uint256(keccak256(abi.encode(_to))));
+    vm.startPrank(_to);
+    tokenProxy.mint(_toExistingBalance);
+    tokenProxy.delegate(_toDelegations);
+    vm.stopPrank();
+    vm.startPrank(_from);
+    tokenProxy.mint(_amount);
+    tokenProxy.delegate(_fromDelegations);
 
-        _expectEmitDelegateVotesChangedEvents(
-            _amount,
-            _toExistingBalance,
-            _fromDelegations,
-            _toDelegations
-        );
-        tokenProxy.transfer(_to, _amount);
-        vm.stopPrank();
-    }
+    _expectEmitDelegateVotesChangedEvents(_amount, _toExistingBalance, _fromDelegations, _toDelegations);
+    tokenProxy.transfer(_to, _amount);
+    vm.stopPrank();
+  }
 
-    function testFuzz_HandlesTransfersToSelf(
-        address _holder,
-        uint256 _transferAmount,
-        uint256 _existingBalance
-    ) public {
-        vm.assume(_holder != address(0));
-        _transferAmount = bound(_transferAmount, 0, type(uint208).max);
-        _existingBalance = bound(
-            _existingBalance,
-            _transferAmount,
-            type(uint208).max
-        );
-        PartialDelegation[] memory _delegations = _createValidPartialDelegation(
-            0,
-            uint256(keccak256(abi.encode(_holder)))
-        );
-        vm.startPrank(_holder);
-        tokenProxy.mint(_existingBalance);
-        tokenProxy.delegate(_delegations);
-        tokenProxy.transfer(_holder, _transferAmount);
-        vm.stopPrank();
-        assertCorrectVotes(_delegations, _existingBalance);
-        assertEq(
-            tokenProxy.balanceOf(_holder),
-            _existingBalance,
-            "holder balance is wrong"
-        );
-        assertEq(
-            tokenProxy.totalSupply(),
-            _existingBalance,
-            "total supply mismatch"
-        );
-    }
+  function testFuzz_HandlesTransfersToSelf(address _holder, uint256 _transferAmount, uint256 _existingBalance) public {
+    vm.assume(_holder != address(0));
+    _transferAmount = bound(_transferAmount, 0, type(uint208).max);
+    _existingBalance = bound(_existingBalance, _transferAmount, type(uint208).max);
+    PartialDelegation[] memory _delegations = _createValidPartialDelegation(0, uint256(keccak256(abi.encode(_holder))));
+    vm.startPrank(_holder);
+    tokenProxy.mint(_existingBalance);
+    tokenProxy.delegate(_delegations);
+    tokenProxy.transfer(_holder, _transferAmount);
+    vm.stopPrank();
+    assertCorrectVotes(_delegations, _existingBalance);
+    assertEq(tokenProxy.balanceOf(_holder), _existingBalance, "holder balance is wrong");
+    assertEq(tokenProxy.totalSupply(), _existingBalance, "total supply mismatch");
+  }
 }
 
 contract Permit is PartialDelegationTest {
-    error ERC20InsufficientAllowance(
-        address spender,
-        uint256 allowance,
-        uint256 needed
+  error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);
+  error ERC2612ExpiredSignature(uint256 deadline);
+  error ERC2612InvalidSigner(address signer, address owner);
+
+  function testFuzz_SuccessfullySetsAllowance(
+    uint256 _holderSeed,
+    address _receiver,
+    uint256 _transferAmount,
+    uint256 _existingBalance,
+    uint256 _deadline
+  ) public {
+    _holderSeed = bound(
+      _holderSeed,
+      1,
+      /* private key can't be bigger than secp256k1 curve order */
+      115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 - 1
     );
-    error ERC2612ExpiredSignature(uint256 deadline);
-    error ERC2612InvalidSigner(address signer, address owner);
+    address _holder = vm.addr(_holderSeed);
+    _deadline = bound(_deadline, block.timestamp, type(uint256).max);
+    vm.assume(_holder != address(0));
+    vm.assume(_receiver != address(0) && _receiver != _holder);
+    _transferAmount = bound(_transferAmount, 0, type(uint208).max);
+    _existingBalance = bound(_existingBalance, _transferAmount, type(uint208).max);
 
-    function testFuzz_SuccessfullySetsAllowance(
-        uint256 _holderSeed,
-        address _receiver,
-        uint256 _transferAmount,
-        uint256 _existingBalance,
-        uint256 _deadline
-    ) public {
-        _holderSeed = bound(
-            _holderSeed,
-            1,
-            /* private key can't be bigger than secp256k1 curve order */
-            115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 -
-                1
-        );
-        address _holder = vm.addr(_holderSeed);
-        _deadline = bound(_deadline, block.timestamp, type(uint256).max);
-        vm.assume(_holder != address(0));
-        vm.assume(_receiver != address(0) && _receiver != _holder);
-        _transferAmount = bound(_transferAmount, 0, type(uint208).max);
-        _existingBalance = bound(
-            _existingBalance,
-            _transferAmount,
-            type(uint208).max
-        );
+    vm.startPrank(_holder);
+    tokenProxy.mint(_existingBalance);
+    bytes32 _message = keccak256(
+      abi.encode(
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"),
+        _holder,
+        _receiver,
+        _transferAmount,
+        tokenProxy.nonces(_holder),
+        _deadline
+      )
+    );
+    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
+    (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_holderSeed, _messageHash);
 
-        vm.startPrank(_holder);
-        tokenProxy.mint(_existingBalance);
-        bytes32 _message = keccak256(
-            abi.encode(
-                keccak256(
-                    "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
-                ),
-                _holder,
-                _receiver,
-                _transferAmount,
-                tokenProxy.nonces(_holder),
-                _deadline
-            )
-        );
-        bytes32 _messageHash = keccak256(
-            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
-        );
-        (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_holderSeed, _messageHash);
+    tokenProxy.permit(_holder, _receiver, _transferAmount, _deadline, _v, _r, _s);
+    vm.stopPrank();
 
-        tokenProxy.permit(
-            _holder,
-            _receiver,
-            _transferAmount,
-            _deadline,
-            _v,
-            _r,
-            _s
-        );
-        vm.stopPrank();
+    assertEq(tokenProxy.allowance(_holder, _receiver), _transferAmount);
+    vm.prank(_receiver);
+    tokenProxy.transferFrom(_holder, _receiver, _transferAmount);
+    assertEq(tokenProxy.balanceOf(_receiver), _transferAmount);
+  }
 
-        assertEq(tokenProxy.allowance(_holder, _receiver), _transferAmount);
-        vm.prank(_receiver);
-        tokenProxy.transferFrom(_holder, _receiver, _transferAmount);
-        assertEq(tokenProxy.balanceOf(_receiver), _transferAmount);
+  function testFuzz_RevertIf_ERC2612ExpiredSignature(
+    uint256 _holderSeed,
+    address _receiver,
+    uint256 _transferAmount,
+    uint256 _existingBalance,
+    uint256 _invalidDeadline
+  ) public {
+    _holderSeed = bound(
+      _holderSeed,
+      1,
+      /* private key can't be bigger than secp256k1 curve order */
+      115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 - 1
+    );
+    address _holder = vm.addr(_holderSeed);
+    _invalidDeadline = bound(_invalidDeadline, 0, block.timestamp - 1);
+    vm.assume(_holder != address(0));
+    vm.assume(_receiver != address(0) && _receiver != _holder);
+    _transferAmount = bound(_transferAmount, 0, type(uint208).max);
+    _existingBalance = bound(_existingBalance, _transferAmount, type(uint208).max);
+
+    vm.startPrank(_holder);
+    tokenProxy.mint(_existingBalance);
+    bytes32 _message = keccak256(
+      abi.encode(
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"),
+        _holder,
+        _receiver,
+        _transferAmount,
+        tokenProxy.nonces(_holder),
+        _invalidDeadline
+      )
+    );
+    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
+    (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_holderSeed, _messageHash);
+
+    vm.expectRevert(abi.encodeWithSelector(ERC2612ExpiredSignature.selector, _invalidDeadline));
+    tokenProxy.permit(_holder, _receiver, _transferAmount, _invalidDeadline, _v, _r, _s);
+    vm.stopPrank();
+  }
+
+  function testFuzz_RevertIf_ERC2612InvalidSigner(
+    uint256 _holderSeed,
+    address _receiver,
+    uint256 _transferAmount,
+    uint256 _existingBalance,
+    uint256 _deadline,
+    uint256 _randomSeed
+  ) public {
+    _holderSeed = bound(
+      _holderSeed,
+      1,
+      /* private key can't be bigger than secp256k1 curve order */
+      115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 - 1
+    );
+    address _holder = vm.addr(_holderSeed);
+    _deadline = bound(_deadline, 0, block.timestamp - 1);
+    vm.assume(_holder != address(0));
+    vm.assume(_receiver != address(0) && _receiver != _holder);
+    _transferAmount = bound(_transferAmount, 0, type(uint208).max);
+    _existingBalance = bound(_existingBalance, _transferAmount, type(uint208).max);
+
+    vm.startPrank(_holder);
+    tokenProxy.mint(_existingBalance);
+    bytes32 _message = keccak256(
+      abi.encode(
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"),
+        _holder,
+        _receiver,
+        _transferAmount,
+        tokenProxy.nonces(_holder),
+        _deadline
+      )
+    );
+    bytes32 _messageHash = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message));
+
+    // Here we use `_randomSeed` as an arbitrary source of randomness to replace a legit parameter
+    // with an attack-like one.
+    if (_randomSeed % 3 == 0) {
+      _receiver = address(uint160(uint256(keccak256(abi.encode(_receiver)))));
+    } else if (_randomSeed % 3 == 1) {
+      _transferAmount = uint256(keccak256(abi.encode(_transferAmount)));
+    }
+    (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_holderSeed, _messageHash);
+    if (_randomSeed % 3 == 2) {
+      (_v, _r, _s) = vm.sign(uint256(keccak256(abi.encode(_holderSeed))), _messageHash);
     }
 
-    function testFuzz_RevertIf_ERC2612ExpiredSignature(
-        uint256 _holderSeed,
-        address _receiver,
-        uint256 _transferAmount,
-        uint256 _existingBalance,
-        uint256 _invalidDeadline
-    ) public {
-        _holderSeed = bound(
-            _holderSeed,
-            1,
-            /* private key can't be bigger than secp256k1 curve order */
-            115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 -
-                1
-        );
-        address _holder = vm.addr(_holderSeed);
-        _invalidDeadline = bound(_invalidDeadline, 0, block.timestamp - 1);
-        vm.assume(_holder != address(0));
-        vm.assume(_receiver != address(0) && _receiver != _holder);
-        _transferAmount = bound(_transferAmount, 0, type(uint208).max);
-        _existingBalance = bound(
-            _existingBalance,
-            _transferAmount,
-            type(uint208).max
-        );
-
-        vm.startPrank(_holder);
-        tokenProxy.mint(_existingBalance);
-        bytes32 _message = keccak256(
-            abi.encode(
-                keccak256(
-                    "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
-                ),
-                _holder,
-                _receiver,
-                _transferAmount,
-                tokenProxy.nonces(_holder),
-                _invalidDeadline
-            )
-        );
-        bytes32 _messageHash = keccak256(
-            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
-        );
-        (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_holderSeed, _messageHash);
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                ERC2612ExpiredSignature.selector,
-                _invalidDeadline
-            )
-        );
-        tokenProxy.permit(
-            _holder,
-            _receiver,
-            _transferAmount,
-            _invalidDeadline,
-            _v,
-            _r,
-            _s
-        );
-        vm.stopPrank();
-    }
-
-    function testFuzz_RevertIf_ERC2612InvalidSigner(
-        uint256 _holderSeed,
-        address _receiver,
-        uint256 _transferAmount,
-        uint256 _existingBalance,
-        uint256 _deadline,
-        uint256 _randomSeed
-    ) public {
-        _holderSeed = bound(
-            _holderSeed,
-            1,
-            /* private key can't be bigger than secp256k1 curve order */
-            115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 -
-                1
-        );
-        address _holder = vm.addr(_holderSeed);
-        _deadline = bound(_deadline, 0, block.timestamp - 1);
-        vm.assume(_holder != address(0));
-        vm.assume(_receiver != address(0) && _receiver != _holder);
-        _transferAmount = bound(_transferAmount, 0, type(uint208).max);
-        _existingBalance = bound(
-            _existingBalance,
-            _transferAmount,
-            type(uint208).max
-        );
-
-        vm.startPrank(_holder);
-        tokenProxy.mint(_existingBalance);
-        bytes32 _message = keccak256(
-            abi.encode(
-                keccak256(
-                    "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
-                ),
-                _holder,
-                _receiver,
-                _transferAmount,
-                tokenProxy.nonces(_holder),
-                _deadline
-            )
-        );
-        bytes32 _messageHash = keccak256(
-            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, _message)
-        );
-
-        // Here we use `_randomSeed` as an arbitrary source of randomness to replace a legit parameter
-        // with an attack-like one.
-        if (_randomSeed % 3 == 0) {
-            _receiver = address(
-                uint160(uint256(keccak256(abi.encode(_receiver))))
-            );
-        } else if (_randomSeed % 3 == 1) {
-            _transferAmount = uint256(keccak256(abi.encode(_transferAmount)));
-        }
-        (uint8 _v, bytes32 _r, bytes32 _s) = vm.sign(_holderSeed, _messageHash);
-        if (_randomSeed % 3 == 2) {
-            (_v, _r, _s) = vm.sign(
-                uint256(keccak256(abi.encode(_holderSeed))),
-                _messageHash
-            );
-        }
-
-        vm.expectRevert(
-            abi.encodeWithSelector(ERC2612ExpiredSignature.selector, _deadline)
-        );
-        tokenProxy.permit(
-            _holder,
-            _receiver,
-            _transferAmount,
-            _deadline,
-            _v,
-            _r,
-            _s
-        );
-        vm.stopPrank();
-    }
+    vm.expectRevert(abi.encodeWithSelector(ERC2612ExpiredSignature.selector, _deadline));
+    tokenProxy.permit(_holder, _receiver, _transferAmount, _deadline, _v, _r, _s);
+    vm.stopPrank();
+  }
 }
 
 contract GetPastVotes is PartialDelegationTest {
-    function testFuzz_ReturnsCorrectVotes(
-        address _actor,
-        uint256 _amount,
-        uint48 _blocksAhead,
-        uint256 _secondMint
-    ) public {
-        vm.assume(_actor != address(0));
-        _amount = bound(_amount, 0, type(uint208).max);
-        _secondMint = bound(_secondMint, 0, type(uint208).max - _amount);
-        uint256 _blockNo = vm.getBlockNumber();
-        _blocksAhead = uint48(
-            bound(_blocksAhead, 1, type(uint48).max - _blockNo)
-        );
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-        vm.stopPrank();
-        PartialDelegation[] memory _delegations = _createValidPartialDelegation(
-            0,
-            uint256(keccak256(abi.encode(_actor)))
-        );
-        vm.startPrank(_actor);
-        tokenProxy.delegate(_delegations);
-        vm.stopPrank();
-        vm.roll(_blockNo + _blocksAhead);
-        vm.startPrank(_actor);
-        // do a second mint that will increase delegatees' votes
-        tokenProxy.mint(_secondMint);
-        vm.stopPrank();
-        assertCorrectPastVotes(_delegations, _amount, _blockNo);
-        assertCorrectVotes(_delegations, _amount + _secondMint);
-    }
-}
-
-contract GetPastTotalSupply is PartialDelegationTest {
-    function testFuzz_ReturnsCorrectPastTotalSupply(
-        address _actor,
-        uint256 _amount,
-        uint48 _blocksAhead,
-        uint256 _secondMint
-    ) public {
-        vm.assume(_actor != address(0));
-        _amount = bound(_amount, 0, type(uint208).max);
-        _secondMint = bound(_secondMint, 0, type(uint208).max - _amount);
-        uint256 _blockNo = vm.getBlockNumber();
-        _blocksAhead = uint48(
-            bound(_blocksAhead, 1, type(uint48).max - _blockNo)
-        );
-        vm.startPrank(_actor);
-        tokenProxy.mint(_amount);
-        vm.roll(_blockNo + _blocksAhead);
-        // do a second mint that will increase total supply
-        tokenProxy.mint(_secondMint);
-        vm.stopPrank();
-        assertEq(tokenProxy.totalSupply(), _amount + _secondMint);
-        assertEq(tokenProxy.getPastTotalSupply(_blockNo), _amount);
-    }
-}
-
-contract VoteableSupplyTest is PartialDelegationTest {
-function testFuzz_VoteableSupplyChangesWithDelegations(
-    address _actor,
-    uint256 _amount,
-    uint48 _blocksAhead,
-    uint256 _secondMint
-) public {
+  function testFuzz_ReturnsCorrectVotes(address _actor, uint256 _amount, uint48 _blocksAhead, uint256 _secondMint)
+    public
+  {
     vm.assume(_actor != address(0));
     _amount = bound(_amount, 0, type(uint208).max);
     _secondMint = bound(_secondMint, 0, type(uint208).max - _amount);
     uint256 _blockNo = vm.getBlockNumber();
-    _blocksAhead = uint48(
-        bound(_blocksAhead, 1, type(uint48).max - _blockNo)
-    );
+    _blocksAhead = uint48(bound(_blocksAhead, 1, type(uint48).max - _blockNo));
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    vm.stopPrank();
+    PartialDelegation[] memory _delegations = _createValidPartialDelegation(0, uint256(keccak256(abi.encode(_actor))));
+    vm.startPrank(_actor);
+    tokenProxy.delegate(_delegations);
+    vm.stopPrank();
+    vm.roll(_blockNo + _blocksAhead);
+    vm.startPrank(_actor);
+    // do a second mint that will increase delegatees' votes
+    tokenProxy.mint(_secondMint);
+    vm.stopPrank();
+    assertCorrectPastVotes(_delegations, _amount, _blockNo);
+    assertCorrectVotes(_delegations, _amount + _secondMint);
+  }
+}
+
+contract GetPastTotalSupply is PartialDelegationTest {
+  function testFuzz_ReturnsCorrectPastTotalSupply(
+    address _actor,
+    uint256 _amount,
+    uint48 _blocksAhead,
+    uint256 _secondMint
+  ) public {
+    vm.assume(_actor != address(0));
+    _amount = bound(_amount, 0, type(uint208).max);
+    _secondMint = bound(_secondMint, 0, type(uint208).max - _amount);
+    uint256 _blockNo = vm.getBlockNumber();
+    _blocksAhead = uint48(bound(_blocksAhead, 1, type(uint48).max - _blockNo));
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    vm.roll(_blockNo + _blocksAhead);
+    // do a second mint that will increase total supply
+    tokenProxy.mint(_secondMint);
+    vm.stopPrank();
+    assertEq(tokenProxy.totalSupply(), _amount + _secondMint);
+    assertEq(tokenProxy.getPastTotalSupply(_blockNo), _amount);
+  }
+}
+
+contract VoteableSupplyTest is PartialDelegationTest {
+  function testFuzz_VoteableSupplyChangesWithDelegations(
+    address _actor,
+    uint256 _amount,
+    uint48 _blocksAhead,
+    uint256 _secondMint
+  ) public {
+    vm.assume(_actor != address(0));
+    _amount = bound(_amount, 0, type(uint208).max);
+    _secondMint = bound(_secondMint, 0, type(uint208).max - _amount);
+    uint256 _blockNo = vm.getBlockNumber();
+    _blocksAhead = uint48(bound(_blocksAhead, 1, type(uint48).max - _blockNo));
 
     // Initial mint
     vm.startPrank(_actor);
@@ -2065,10 +1474,7 @@ function testFuzz_VoteableSupplyChangesWithDelegations(
     assertEq(voteableSupply, 0, "Initial voteable supply should be 0");
 
     // First delegation
-    PartialDelegation[] memory delegations = _createValidPartialDelegation(
-        0,
-        uint256(keccak256(abi.encode(_actor)))
-    );
+    PartialDelegation[] memory delegations = _createValidPartialDelegation(0, uint256(keccak256(abi.encode(_actor))));
     vm.startPrank(_actor);
     tokenProxy.delegate(delegations);
     vm.stopPrank();
@@ -2092,416 +1498,275 @@ function testFuzz_VoteableSupplyChangesWithDelegations(
     console.log("Second Mint Amount:", _secondMint);
     console.log("Final Total Supply:", tokenProxy.totalSupply());
     console.log("Final Voteable Supply:", tokenProxy.getVoteableSupply());
-}
+  }
 }
 
 // This contract strengthens our confidence in our test helper, `_expectEmitDelegateVotesChangedEvents`
 contract ExpectEmitDelegateVotesChangedEvents is PartialDelegationTest {
-    /// An Ethereum log. Returned by `getRecordedLogs`.
+  /// An Ethereum log. Returned by `getRecordedLogs`.
 
-    function test_EmitsWhenFromNoDelegateeToANewDelegateeIsAdded() public {
-        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](0);
-        PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
-        _newDelegations[0] = PartialDelegation({
-            _delegatee: address(0x1),
-            _numerator: 10_000
-        });
+  function test_EmitsWhenFromNoDelegateeToANewDelegateeIsAdded() public {
+    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](0);
+    PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
+    _newDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 10_000});
 
-        vm.recordLogs();
-        _expectEmitDelegateVotesChangedEvents(
-            100,
-            _oldDelegations,
-            _newDelegations
-        );
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        uint256 _logLength = entries.length;
+    vm.recordLogs();
+    _expectEmitDelegateVotesChangedEvents(100, _oldDelegations, _newDelegations);
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+    uint256 _logLength = entries.length;
 
-        // Initialized(18_446_744_073_709_551_615) from FakeERC20VotesPartialDelegationUpgradeable utils = new
-        // FakeERC20VotesPartialDelegationUpgradeable();
-        assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
-        emit DelegateVotesChanged(address(0x1), 0, 100);
-        assertEq(_logLength, 2);
-    }
+    // Initialized(18_446_744_073_709_551_615) from FakeERC20VotesPartialDelegationUpgradeable utils = new
+    // FakeERC20VotesPartialDelegationUpgradeable();
+    assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
+    emit DelegateVotesChanged(address(0x1), 0, 100);
+    assertEq(_logLength, 2);
+  }
 
-    function test_EmitsWhenBothDelegationsHaveTheSameDelegatee() public {
-        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
-        _oldDelegations[0] = PartialDelegation({
-            _delegatee: address(0x1),
-            _numerator: 10_000
-        });
-        PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
-        _newDelegations[0] = PartialDelegation({
-            _delegatee: address(0x1),
-            _numerator: 10_000
-        });
+  function test_EmitsWhenBothDelegationsHaveTheSameDelegatee() public {
+    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
+    _oldDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 10_000});
+    PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
+    _newDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 10_000});
 
-        vm.recordLogs();
-        _expectEmitDelegateVotesChangedEvents(
-            100,
-            _oldDelegations,
-            _newDelegations
-        );
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        uint256 _logLength = entries.length;
+    vm.recordLogs();
+    _expectEmitDelegateVotesChangedEvents(100, _oldDelegations, _newDelegations);
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+    uint256 _logLength = entries.length;
 
-        assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
-        assertEq(_logLength, 1);
-    }
+    assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
+    assertEq(_logLength, 1);
+  }
 
-    function test_EmitsWhenBothDelegationsHaveTheSameDelegateeButDifferentNumerators()
-        public
-    {
-        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
-        _oldDelegations[0] = PartialDelegation({
-            _delegatee: address(0x1),
-            _numerator: 10_000
-        });
-        PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
-        _newDelegations[0] = PartialDelegation({
-            _delegatee: address(0x1),
-            _numerator: 5000
-        });
+  function test_EmitsWhenBothDelegationsHaveTheSameDelegateeButDifferentNumerators() public {
+    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
+    _oldDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 10_000});
+    PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
+    _newDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 5000});
 
-        vm.recordLogs();
-        _expectEmitDelegateVotesChangedEvents(
-            100,
-            _oldDelegations,
-            _newDelegations
-        );
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        uint256 _logLength = entries.length;
+    vm.recordLogs();
+    _expectEmitDelegateVotesChangedEvents(100, _oldDelegations, _newDelegations);
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+    uint256 _logLength = entries.length;
 
-        assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
-        emit DelegateVotesChanged(address(0x1), 100, 50);
-        assertEq(_logLength, 2);
-    }
+    assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
+    emit DelegateVotesChanged(address(0x1), 100, 50);
+    assertEq(_logLength, 2);
+  }
 
-    function test_EmitsWhenOldDelegateeComesBeforeTheNewDelegatee() public {
-        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
-        _oldDelegations[0] = PartialDelegation({
-            _delegatee: address(0x1),
-            _numerator: 10_000
-        });
-        PartialDelegation[] memory _newDelegations = new PartialDelegation[](2);
-        _newDelegations[0] = PartialDelegation({
-            _delegatee: address(0x1),
-            _numerator: 5000
-        });
-        _newDelegations[1] = PartialDelegation({
-            _delegatee: address(0x2),
-            _numerator: 5000
-        });
+  function test_EmitsWhenOldDelegateeComesBeforeTheNewDelegatee() public {
+    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
+    _oldDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 10_000});
+    PartialDelegation[] memory _newDelegations = new PartialDelegation[](2);
+    _newDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 5000});
+    _newDelegations[1] = PartialDelegation({_delegatee: address(0x2), _numerator: 5000});
 
-        vm.recordLogs();
-        _expectEmitDelegateVotesChangedEvents(
-            100,
-            _oldDelegations,
-            _newDelegations
-        );
+    vm.recordLogs();
+    _expectEmitDelegateVotesChangedEvents(100, _oldDelegations, _newDelegations);
 
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        uint256 _logLength = entries.length;
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+    uint256 _logLength = entries.length;
 
-        assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
-        emit DelegateVotesChanged(address(0x1), 100, 50);
-        emit DelegateVotesChanged(address(0x2), 0, 50);
-        assertEq(_logLength, 3);
-    }
+    assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
+    emit DelegateVotesChanged(address(0x1), 100, 50);
+    emit DelegateVotesChanged(address(0x2), 0, 50);
+    assertEq(_logLength, 3);
+  }
 
-    function test_EmitsWhenNewDelegateeComesBeforeTheOldDelegateeReplacingTheOldDelegatee()
-        public
-    {
-        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
-        _oldDelegations[0] = PartialDelegation({
-            _delegatee: address(0x2),
-            _numerator: 10_000
-        });
-        PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
-        _newDelegations[0] = PartialDelegation({
-            _delegatee: address(0x1),
-            _numerator: 10_000
-        });
+  function test_EmitsWhenNewDelegateeComesBeforeTheOldDelegateeReplacingTheOldDelegatee() public {
+    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
+    _oldDelegations[0] = PartialDelegation({_delegatee: address(0x2), _numerator: 10_000});
+    PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
+    _newDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 10_000});
 
-        vm.recordLogs();
-        _expectEmitDelegateVotesChangedEvents(
-            100,
-            _oldDelegations,
-            _newDelegations
-        );
+    vm.recordLogs();
+    _expectEmitDelegateVotesChangedEvents(100, _oldDelegations, _newDelegations);
 
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        uint256 _logLength = entries.length;
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+    uint256 _logLength = entries.length;
 
-        assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
-        emit DelegateVotesChanged(address(0x1), 0, 100);
-        emit DelegateVotesChanged(address(0x2), 100, 0);
-        assertEq(_logLength, 3);
-    }
+    assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
+    emit DelegateVotesChanged(address(0x1), 0, 100);
+    emit DelegateVotesChanged(address(0x2), 100, 0);
+    assertEq(_logLength, 3);
+  }
 
-    function test_EmitsWhenNewDelegateeComesBeforeTheOldDelegateeIncludingThePreviousDelegatee()
-        public
-    {
-        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
-        _oldDelegations[0] = PartialDelegation({
-            _delegatee: address(0x2),
-            _numerator: 10_000
-        });
-        PartialDelegation[] memory _newDelegations = new PartialDelegation[](2);
-        _newDelegations[0] = PartialDelegation({
-            _delegatee: address(0x1),
-            _numerator: 5000
-        });
-        _newDelegations[1] = PartialDelegation({
-            _delegatee: address(0x2),
-            _numerator: 5000
-        });
+  function test_EmitsWhenNewDelegateeComesBeforeTheOldDelegateeIncludingThePreviousDelegatee() public {
+    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
+    _oldDelegations[0] = PartialDelegation({_delegatee: address(0x2), _numerator: 10_000});
+    PartialDelegation[] memory _newDelegations = new PartialDelegation[](2);
+    _newDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 5000});
+    _newDelegations[1] = PartialDelegation({_delegatee: address(0x2), _numerator: 5000});
 
-        vm.recordLogs();
-        _expectEmitDelegateVotesChangedEvents(
-            100,
-            _oldDelegations,
-            _newDelegations
-        );
+    vm.recordLogs();
+    _expectEmitDelegateVotesChangedEvents(100, _oldDelegations, _newDelegations);
 
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        uint256 _logLength = entries.length;
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+    uint256 _logLength = entries.length;
 
-        assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
-        emit DelegateVotesChanged(address(0x1), 0, 50);
-        emit DelegateVotesChanged(address(0x2), 100, 50);
-        assertEq(_logLength, 3);
-    }
+    assertEq(entries[0].topics[0], keccak256("Initialized(uint64)"));
+    emit DelegateVotesChanged(address(0x1), 0, 50);
+    emit DelegateVotesChanged(address(0x2), 100, 50);
+    assertEq(_logLength, 3);
+  }
 }
 
 // This contract strengthens our confidence in our test helper, `_expectEmitDelegateVotesChangedEvents` (the 4 param
 // version)
-contract ExpectEmitDelegateVotesChangedEventsDuringTransfer is
-    PartialDelegationTest
-{
-    function test_EmitsWhenTransferringTokensFromAnAddressWithNoDelegationsToAnAddressWithNoDelegations()
-        public
-    {
-        address from = address(0x10);
-        address to = address(0x20);
-        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](0);
-        PartialDelegation[] memory _newDelegations = new PartialDelegation[](0);
+contract ExpectEmitDelegateVotesChangedEventsDuringTransfer is PartialDelegationTest {
+  function test_EmitsWhenTransferringTokensFromAnAddressWithNoDelegationsToAnAddressWithNoDelegations() public {
+    address from = address(0x10);
+    address to = address(0x20);
+    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](0);
+    PartialDelegation[] memory _newDelegations = new PartialDelegation[](0);
 
-        vm.prank(from);
-        tokenProxy.mint(100);
+    vm.prank(from);
+    tokenProxy.mint(100);
 
-        vm.prank(to);
-        tokenProxy.mint(100);
+    vm.prank(to);
+    tokenProxy.mint(100);
 
-        vm.recordLogs();
-        _expectEmitDelegateVotesChangedEvents(
-            100,
-            100,
-            _oldDelegations,
-            _newDelegations
-        );
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        uint256 _logLength = entries.length;
+    vm.recordLogs();
+    _expectEmitDelegateVotesChangedEvents(100, 100, _oldDelegations, _newDelegations);
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+    uint256 _logLength = entries.length;
 
-        assertEq(_logLength, 0);
-    }
+    assertEq(_logLength, 0);
+  }
 
-    function test_EmitsWhenTransferringTokensFromAnAddressWithSingleDelegateeToAnAddressWithNoDelegations()
-        public
-    {
-        address from = address(0x10);
-        address to = address(0x20);
-        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
-        _oldDelegations[0] = PartialDelegation({
-            _delegatee: address(0x1),
-            _numerator: 10_000
-        });
-        PartialDelegation[] memory _newDelegations = new PartialDelegation[](0);
+  function test_EmitsWhenTransferringTokensFromAnAddressWithSingleDelegateeToAnAddressWithNoDelegations() public {
+    address from = address(0x10);
+    address to = address(0x20);
+    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
+    _oldDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 10_000});
+    PartialDelegation[] memory _newDelegations = new PartialDelegation[](0);
 
-        vm.startPrank(from);
-        tokenProxy.mint(100);
-        tokenProxy.delegate(_oldDelegations);
-        vm.stopPrank();
+    vm.startPrank(from);
+    tokenProxy.mint(100);
+    tokenProxy.delegate(_oldDelegations);
+    vm.stopPrank();
 
-        vm.prank(to);
-        tokenProxy.mint(100);
+    vm.prank(to);
+    tokenProxy.mint(100);
 
-        vm.recordLogs();
-        _expectEmitDelegateVotesChangedEvents(
-            100,
-            100,
-            _oldDelegations,
-            _newDelegations
-        );
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        uint256 _logLength = entries.length;
+    vm.recordLogs();
+    _expectEmitDelegateVotesChangedEvents(100, 100, _oldDelegations, _newDelegations);
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+    uint256 _logLength = entries.length;
 
-        emit DelegateVotesChanged(address(0x1), 100, 0);
-        assertEq(_logLength, 1);
-    }
+    emit DelegateVotesChanged(address(0x1), 100, 0);
+    assertEq(_logLength, 1);
+  }
 
-    function test_EmitsWhenTransferringTokensFromAnAddressWithSingleDelegateeToAnAddressWithASingleDelegatee()
-        public
-    {
-        address from = address(0x10);
-        address to = address(0x20);
-        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
-        _oldDelegations[0] = PartialDelegation({
-            _delegatee: address(0x1),
-            _numerator: 10_000
-        });
-        PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
-        _newDelegations[0] = PartialDelegation({
-            _delegatee: address(0x2),
-            _numerator: 10_000
-        });
+  function test_EmitsWhenTransferringTokensFromAnAddressWithSingleDelegateeToAnAddressWithASingleDelegatee() public {
+    address from = address(0x10);
+    address to = address(0x20);
+    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](1);
+    _oldDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 10_000});
+    PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
+    _newDelegations[0] = PartialDelegation({_delegatee: address(0x2), _numerator: 10_000});
 
-        vm.startPrank(from);
-        tokenProxy.mint(100);
-        tokenProxy.delegate(_oldDelegations);
-        vm.stopPrank();
+    vm.startPrank(from);
+    tokenProxy.mint(100);
+    tokenProxy.delegate(_oldDelegations);
+    vm.stopPrank();
 
-        vm.startPrank(to);
-        tokenProxy.mint(100);
-        tokenProxy.delegate(_newDelegations);
-        vm.stopPrank();
+    vm.startPrank(to);
+    tokenProxy.mint(100);
+    tokenProxy.delegate(_newDelegations);
+    vm.stopPrank();
 
-        vm.recordLogs();
-        _expectEmitDelegateVotesChangedEvents(
-            100,
-            100,
-            _oldDelegations,
-            _newDelegations
-        );
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        uint256 _logLength = entries.length;
+    vm.recordLogs();
+    _expectEmitDelegateVotesChangedEvents(100, 100, _oldDelegations, _newDelegations);
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+    uint256 _logLength = entries.length;
 
-        emit DelegateVotesChanged(address(0x1), 100, 0);
-        emit DelegateVotesChanged(address(0x2), 100, 200);
-        assertEq(_logLength, 2);
-    }
+    emit DelegateVotesChanged(address(0x1), 100, 0);
+    emit DelegateVotesChanged(address(0x2), 100, 200);
+    assertEq(_logLength, 2);
+  }
 
-    function test_EmitsWhenTransferringTokensFromAnAddressWithNoDelegationsToAnAddressWithASingleDelegatee()
-        public
-    {
-        address from = address(0x10);
-        address to = address(0x20);
-        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](0);
-        PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
-        _newDelegations[0] = PartialDelegation({
-            _delegatee: address(0x2),
-            _numerator: 10_000
-        });
+  function test_EmitsWhenTransferringTokensFromAnAddressWithNoDelegationsToAnAddressWithASingleDelegatee() public {
+    address from = address(0x10);
+    address to = address(0x20);
+    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](0);
+    PartialDelegation[] memory _newDelegations = new PartialDelegation[](1);
+    _newDelegations[0] = PartialDelegation({_delegatee: address(0x2), _numerator: 10_000});
 
-        vm.prank(from);
-        tokenProxy.mint(100);
+    vm.prank(from);
+    tokenProxy.mint(100);
 
-        vm.startPrank(to);
-        tokenProxy.mint(100);
-        tokenProxy.delegate(_newDelegations);
-        vm.stopPrank();
+    vm.startPrank(to);
+    tokenProxy.mint(100);
+    tokenProxy.delegate(_newDelegations);
+    vm.stopPrank();
 
-        vm.recordLogs();
-        _expectEmitDelegateVotesChangedEvents(
-            100,
-            100,
-            _oldDelegations,
-            _newDelegations
-        );
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        uint256 _logLength = entries.length;
+    vm.recordLogs();
+    _expectEmitDelegateVotesChangedEvents(100, 100, _oldDelegations, _newDelegations);
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+    uint256 _logLength = entries.length;
 
-        emit DelegateVotesChanged(address(0x2), 100, 200);
-        assertEq(_logLength, 1);
-    }
+    emit DelegateVotesChanged(address(0x2), 100, 200);
+    assertEq(_logLength, 1);
+  }
 
-    function test_EmitsWhenTransferringTokensFromAnAddressWithNoDelegationsToAnAddressWithMultipleDelegatees()
-        public
-    {
-        address from = address(0x10);
-        address to = address(0x20);
-        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](0);
-        PartialDelegation[] memory _newDelegations = new PartialDelegation[](2);
-        _newDelegations[0] = PartialDelegation({
-            _delegatee: address(0x2),
-            _numerator: 5000
-        });
-        _newDelegations[1] = PartialDelegation({
-            _delegatee: address(0x3),
-            _numerator: 5000
-        });
+  function test_EmitsWhenTransferringTokensFromAnAddressWithNoDelegationsToAnAddressWithMultipleDelegatees() public {
+    address from = address(0x10);
+    address to = address(0x20);
+    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](0);
+    PartialDelegation[] memory _newDelegations = new PartialDelegation[](2);
+    _newDelegations[0] = PartialDelegation({_delegatee: address(0x2), _numerator: 5000});
+    _newDelegations[1] = PartialDelegation({_delegatee: address(0x3), _numerator: 5000});
 
-        vm.prank(from);
-        tokenProxy.mint(100);
+    vm.prank(from);
+    tokenProxy.mint(100);
 
-        vm.startPrank(to);
-        tokenProxy.mint(100);
-        tokenProxy.delegate(_newDelegations);
-        vm.stopPrank();
+    vm.startPrank(to);
+    tokenProxy.mint(100);
+    tokenProxy.delegate(_newDelegations);
+    vm.stopPrank();
 
-        vm.recordLogs();
-        _expectEmitDelegateVotesChangedEvents(
-            100,
-            100,
-            _oldDelegations,
-            _newDelegations
-        );
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        uint256 _logLength = entries.length;
+    vm.recordLogs();
+    _expectEmitDelegateVotesChangedEvents(100, 100, _oldDelegations, _newDelegations);
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+    uint256 _logLength = entries.length;
 
-        emit DelegateVotesChanged(address(0x2), 50, 100);
-        emit DelegateVotesChanged(address(0x3), 50, 100);
-        assertEq(_logLength, 2);
-    }
+    emit DelegateVotesChanged(address(0x2), 50, 100);
+    emit DelegateVotesChanged(address(0x3), 50, 100);
+    assertEq(_logLength, 2);
+  }
 
-    function test_EmitsWhenTransferringTokensFromAnAddressWithMultipleDelegateesToAnAddressWithMultipleDelegatees()
-        public
-    {
-        address from = address(0x10);
-        address to = address(0x20);
-        PartialDelegation[] memory _oldDelegations = new PartialDelegation[](2);
-        _oldDelegations[0] = PartialDelegation({
-            _delegatee: address(0x1),
-            _numerator: 5000
-        });
-        _oldDelegations[1] = PartialDelegation({
-            _delegatee: address(0x2),
-            _numerator: 5000
-        });
+  function test_EmitsWhenTransferringTokensFromAnAddressWithMultipleDelegateesToAnAddressWithMultipleDelegatees()
+    public
+  {
+    address from = address(0x10);
+    address to = address(0x20);
+    PartialDelegation[] memory _oldDelegations = new PartialDelegation[](2);
+    _oldDelegations[0] = PartialDelegation({_delegatee: address(0x1), _numerator: 5000});
+    _oldDelegations[1] = PartialDelegation({_delegatee: address(0x2), _numerator: 5000});
 
-        PartialDelegation[] memory _newDelegations = new PartialDelegation[](2);
-        _newDelegations[0] = PartialDelegation({
-            _delegatee: address(0x3),
-            _numerator: 5000
-        });
-        _newDelegations[1] = PartialDelegation({
-            _delegatee: address(0x4),
-            _numerator: 5000
-        });
+    PartialDelegation[] memory _newDelegations = new PartialDelegation[](2);
+    _newDelegations[0] = PartialDelegation({_delegatee: address(0x3), _numerator: 5000});
+    _newDelegations[1] = PartialDelegation({_delegatee: address(0x4), _numerator: 5000});
 
-        vm.startPrank(from);
-        tokenProxy.mint(100);
-        tokenProxy.delegate(_oldDelegations);
-        vm.stopPrank();
+    vm.startPrank(from);
+    tokenProxy.mint(100);
+    tokenProxy.delegate(_oldDelegations);
+    vm.stopPrank();
 
-        vm.startPrank(to);
-        tokenProxy.mint(100);
-        tokenProxy.delegate(_newDelegations);
-        vm.stopPrank();
+    vm.startPrank(to);
+    tokenProxy.mint(100);
+    tokenProxy.delegate(_newDelegations);
+    vm.stopPrank();
 
-        vm.recordLogs();
-        _expectEmitDelegateVotesChangedEvents(
-            100,
-            100,
-            _oldDelegations,
-            _newDelegations
-        );
-        Vm.Log[] memory entries = vm.getRecordedLogs();
-        uint256 _logLength = entries.length;
+    vm.recordLogs();
+    _expectEmitDelegateVotesChangedEvents(100, 100, _oldDelegations, _newDelegations);
+    Vm.Log[] memory entries = vm.getRecordedLogs();
+    uint256 _logLength = entries.length;
 
-        emit DelegateVotesChanged(address(0x1), 50, 0);
-        emit DelegateVotesChanged(address(0x2), 50, 0);
-        emit DelegateVotesChanged(address(0x3), 50, 100);
-        emit DelegateVotesChanged(address(0x4), 50, 100);
-        assertEq(_logLength, 4);
-    }
+    emit DelegateVotesChanged(address(0x1), 50, 0);
+    emit DelegateVotesChanged(address(0x2), 50, 0);
+    emit DelegateVotesChanged(address(0x3), 50, 100);
+    emit DelegateVotesChanged(address(0x4), 50, 100);
+    assertEq(_logLength, 4);
+  }
 }

--- a/test/ERC20VotesPartialDelegationUpgradeable.t.sol
+++ b/test/ERC20VotesPartialDelegationUpgradeable.t.sol
@@ -66,6 +66,11 @@ contract PartialDelegationTest is DelegationAndEventHelpers {
     assertLe(_totalWeight, _amount, "incorrect total weight");
   }
 
+  function assertCorrectVotableSupply(PartialDelegation[] memory _delegations, uint256 _amount) internal {
+    uint256 _totalWeight = _calculateWeightDelegated(_delegations, _amount);
+    assertEq(_totalWeight, tokenProxy.getVoteableSupply(), "incorrect votable supply");
+  }
+
   function assertCorrectPastVotes(PartialDelegation[] memory _delegations, uint256 _amount, uint256 _timepoint)
     internal
   {
@@ -85,6 +90,7 @@ contract PartialDelegationTest is DelegationAndEventHelpers {
 
   function _calculateWeightDelegated(PartialDelegation[] memory _delegations, uint256 _amount)
     internal
+    view
     returns (uint256)
   {
     DelegationAdjustment[] memory _votes = tokenProxy.exposed_calculateWeightDistribution(_delegations, _amount);
@@ -198,6 +204,7 @@ contract Delegate is PartialDelegationTest {
     assertEq(tokenProxy.delegates(_actor), delegations);
     DelegationAdjustment[] memory adjustments = tokenProxy.exposed_calculateWeightDistribution(delegations, _amount);
     assertEq(tokenProxy.getVotes(_delegatee), adjustments[0]._amount);
+    assertCorrectVotableSupply(delegations, _amount);
   }
 
   function testFuzz_DelegatesOnlyToZeroAddress(address _actor, uint96 _numerator, uint256 _amount) public {
@@ -213,6 +220,7 @@ contract Delegate is PartialDelegationTest {
     vm.stopPrank();
     assertEq(tokenProxy.delegates(_actor), delegations);
     assertEq(tokenProxy.getVotes(_delegatee), 0);
+    assertCorrectVotableSupply(delegations, _amount);
   }
 
   function testFuzz_DelegatesToTwoAddresses(
@@ -239,6 +247,7 @@ contract Delegate is PartialDelegationTest {
     vm.stopPrank();
     assertEq(tokenProxy.delegates(_actor), delegations);
     assertCorrectVotes(delegations, _amount);
+    assertCorrectVotableSupply(delegations, _amount);
   }
 
   function testFuzz_DelegatesToNAddresses(address _actor, uint256 _amount, uint256 _n, uint256 _seed) public {
@@ -252,6 +261,7 @@ contract Delegate is PartialDelegationTest {
     vm.stopPrank();
     assertEq(tokenProxy.delegates(_actor), delegations);
     assertCorrectVotes(delegations, _amount);
+    assertCorrectVotableSupply(delegations, _amount);
   }
 
   function testFuzz_DelegatesToNAddressesAndThenDelegatesToOtherAddresses(
@@ -284,6 +294,7 @@ contract Delegate is PartialDelegationTest {
     for (uint256 i = 0; i < delegations.length; i++) {
       assertEq(tokenProxy.getVotes(delegations[i]._delegatee), 0, "initial delegate has vote power");
     }
+    assertCorrectVotableSupply(newDelegations, _amount);
   }
 
   function testFuzz_EmitsDelegateChangedEvents(address _actor, uint256 _amount, uint256 _n, uint256 _seed) public {
@@ -500,6 +511,22 @@ contract Delegate is PartialDelegationTest {
     vm.stopPrank();
   }
 
+  function testFuzz_EmitsVotableSupplyChangedEvent(address _actor, uint256 _amount, uint256 _n, uint256 _seed) public {
+    vm.assume(_actor != address(0));
+    _amount = bound(_amount, 0, type(uint208).max);
+    _n = bound(_n, 1, tokenProxy.MAX_PARTIAL_DELEGATIONS());
+    PartialDelegation[] memory delegations = _createValidPartialDelegation(_n, _seed);
+    uint256 _expectedVotableSupply = _calculateWeightDelegated(delegations, _amount);
+    vm.startPrank(_actor);
+    tokenProxy.mint(_amount);
+    if (_expectedVotableSupply > 0) {
+      vm.expectEmit();
+      emit VotableSupplyChanged(0, _expectedVotableSupply);
+    }
+    tokenProxy.delegate(delegations);
+    vm.stopPrank();
+  }
+
   function testFuzz_RevertIf_DelegationArrayIncludesDuplicates(
     address _actor,
     address _delegatee,
@@ -673,6 +700,7 @@ contract DelegateLegacy is PartialDelegationTest {
     tokenProxy.delegate(_delegatee);
     assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_delegatee));
     assertEq(tokenProxy.getVotes(_delegatee), _delegatorBalance);
+    assertEq(tokenProxy.getVoteableSupply(), _delegatorBalance);
   }
 
   function testFuzz_DelegatesSuccessfullyToZeroAddress(
@@ -691,6 +719,7 @@ contract DelegateLegacy is PartialDelegationTest {
     tokenProxy.delegate(_delegatee);
     assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_delegatee));
     assertEq(tokenProxy.getVotes(_delegatee), 0);
+    assertEq(tokenProxy.getVoteableSupply(), 0);
   }
 
   function testFuzz_RedelegatesSuccessfully(
@@ -717,6 +746,7 @@ contract DelegateLegacy is PartialDelegationTest {
     assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_newDelegatee));
     _expectedVotes = _newDelegatee == address(0) ? 0 : _delegatorBalance;
     assertEq(tokenProxy.getVotes(_newDelegatee), _expectedVotes);
+    assertEq(tokenProxy.getVoteableSupply(), _expectedVotes);
   }
 
   function testFuzz_RedelegatesToAPartialDelegationSuccessfully(
@@ -743,6 +773,7 @@ contract DelegateLegacy is PartialDelegationTest {
     tokenProxy.delegate(newDelegations);
     assertEq(tokenProxy.delegates(_delegator), newDelegations);
     assertCorrectVotes(newDelegations, _delegatorBalance);
+    assertCorrectVotableSupply(newDelegations, _delegatorBalance);
   }
 }
 
@@ -774,6 +805,7 @@ contract DelegateBySig is PartialDelegationTest {
     tokenProxy.delegateBySig(_delegatee, _currentNonce, _deadline, _v, _r, _s);
     assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_delegatee));
     assertEq(tokenProxy.getVotes(_delegatee), _delegatorBalance);
+    assertEq(tokenProxy.getVoteableSupply(), _delegatorBalance);
   }
 
   function testFuzz_DelegatesSuccessfullyToZeroAddress(
@@ -800,6 +832,7 @@ contract DelegateBySig is PartialDelegationTest {
     tokenProxy.delegateBySig(_delegatee, _currentNonce, _deadline, _v, _r, _s);
     assertEq(tokenProxy.delegates(_delegator), _createSingleFullDelegation(_delegatee));
     assertEq(tokenProxy.getVotes(_delegatee), 0);
+    assertEq(tokenProxy.getVoteableSupply(), 0);
   }
 
   function testFuzz_RevertIf_DelegatesViaERC712SignatureWithExpiredDeadline(
@@ -936,6 +969,7 @@ contract DelegatePartiallyOnBehalf is PartialDelegationTest {
     vm.prank(_actor);
     tokenProxy.delegatePartiallyOnBehalf(_delegator, _delegations, _currentNonce, _deadline, _signature);
     assertEq(tokenProxy.delegates(_delegator), _delegations);
+    assertCorrectVotableSupply(_delegations, _delegatorBalance);
   }
 
   function testFuzz_DelegatesSuccessfullyViaERC1271Signer(
@@ -967,6 +1001,7 @@ contract DelegatePartiallyOnBehalf is PartialDelegationTest {
     vm.prank(_actor);
     tokenProxy.delegatePartiallyOnBehalf(_delegator, _delegations, _currentNonce, _deadline, _signature);
     assertEq(tokenProxy.delegates(_delegator), _delegations);
+    assertCorrectVotableSupply(_delegations, _delegatorBalance);
   }
 
   function testFuzz_RevertIf_DelegatesViaERC712SignerWithWrongNonce(
@@ -1231,6 +1266,7 @@ contract Transfer is PartialDelegationTest {
     assertEq(tokenProxy.balanceOf(_from), 0, "nonzero `from` balance");
     assertEq(tokenProxy.balanceOf(_to), _toExistingBalance + _amount, "`to` balance mismatch");
     assertEq(tokenProxy.totalSupply(), _toExistingBalance + _amount, "total supply mismatch");
+    assertCorrectVotableSupply(_toDelegations, _toExistingBalance + _amount);
   }
 
   function testFuzz_EmitsDelegateVotesChangedEventsWhenVotesMoveFromOneDelegateeSetToAnother(
@@ -1260,6 +1296,43 @@ contract Transfer is PartialDelegationTest {
     vm.stopPrank();
   }
 
+  function testFuzz_EmitsVotableSupplyChangedEventsWhenVotesMoveFromOneDelegateeSetToAnother(
+    address _from,
+    address _to,
+    uint256 _amount,
+    uint256 _toExistingBalance
+  ) public {
+    vm.assume(_from != address(0));
+    vm.assume(_to != address(0));
+    vm.assume(_from != _to);
+    _amount = bound(_amount, 1, type(uint208).max);
+    _toExistingBalance = bound(_toExistingBalance, 0, type(uint208).max - _amount);
+    PartialDelegation[] memory _fromDelegations =
+      _createValidPartialDelegation(0, uint256(keccak256(abi.encode(_from))));
+    PartialDelegation[] memory _toDelegations = _createValidPartialDelegation(0, uint256(keccak256(abi.encode(_to))));
+    vm.startPrank(_to);
+    tokenProxy.mint(_toExistingBalance);
+    tokenProxy.delegate(_toDelegations);
+    vm.stopPrank();
+    uint256 _votableSupplyBefore = _calculateWeightDelegated(_toDelegations, _toExistingBalance);
+    vm.startPrank(_from);
+    uint256 _votableSupplyBefore2 = _votableSupplyBefore + _calculateWeightDelegated(_fromDelegations, _amount);
+    tokenProxy.mint(_amount);
+    if (_votableSupplyBefore2 != _votableSupplyBefore) {
+      vm.expectEmit();
+      emit VotableSupplyChanged(_votableSupplyBefore, _votableSupplyBefore2);
+    }
+    tokenProxy.delegate(_fromDelegations);
+
+    uint256 _votableSupplyAfter = _calculateWeightDelegated(_toDelegations, _toExistingBalance + _amount);
+    if (_votableSupplyAfter != _votableSupplyBefore2) {
+      vm.expectEmit();
+      emit VotableSupplyChanged(_votableSupplyBefore2, _votableSupplyAfter);
+    }
+    tokenProxy.transfer(_to, _amount);
+    vm.stopPrank();
+  }
+
   function testFuzz_HandlesTransfersToSelf(address _holder, uint256 _transferAmount, uint256 _existingBalance) public {
     vm.assume(_holder != address(0));
     _transferAmount = bound(_transferAmount, 0, type(uint208).max);
@@ -1273,6 +1346,7 @@ contract Transfer is PartialDelegationTest {
     assertCorrectVotes(_delegations, _existingBalance);
     assertEq(tokenProxy.balanceOf(_holder), _existingBalance, "holder balance is wrong");
     assertEq(tokenProxy.totalSupply(), _existingBalance, "total supply mismatch");
+    assertCorrectVotableSupply(_delegations, _existingBalance);
   }
 }
 

--- a/test/helpers/DelegationAndEventHelpers.sol
+++ b/test/helpers/DelegationAndEventHelpers.sol
@@ -16,6 +16,8 @@ contract DelegationAndEventHelpers is Test {
   /// @dev Emitted when a token transfer or delegate change results in changes to a delegate's number of voting units.
   event DelegateVotesChanged(address indexed delegate, uint256 previousVotes, uint256 newVotes);
 
+  event VotableSupplyChanged(uint256 oldVotableSupply, uint256 newVotableSupply);
+
   function initialize(address _token) public virtual {
     token = ERC20VotesPartialDelegationUpgradeable(_token);
   }


### PR DESCRIPTION
Quick and dirty implementation of getVoteableSupply using checkpoints. 

Goal is for VoteableSupply to track the number of actively delegated tokens at any given time. 
Total supply = Total Universe of Minted tokens that can be used for voting.
Voteable supply = Total universe of actively delegated tokens held by delegates.

Should be able to get the value at a point in time and the most current one based on latest checkpoint.