### PR TITLE
Use `_msgSender()` and safe cast

### DIFF
--- a/src/VotesPartialDelegationUpgradeable.sol
+++ b/src/VotesPartialDelegationUpgradeable.sol
@@ -348,7 +348,7 @@ abstract contract VotesPartialDelegationUpgradeable is
    * actions.
    */
   function invalidateNonce() external {
-    _useNonce(msg.sender);
+    _useNonce(_msgSender());
   }
 
   /**
@@ -570,8 +570,9 @@ abstract contract VotesPartialDelegationUpgradeable is
       if (_delegations[i]._numerator == 0) {
         revert InvalidNumeratorZero();
       }
-      _delegationAdjustments[i] =
-        DelegationAdjustment(_delegations[i]._delegatee, uint208(_amount * _delegations[i]._numerator / DENOMINATOR));
+      _delegationAdjustments[i] = DelegationAdjustment(
+        _delegations[i]._delegatee, SafeCast.toUint208(_amount * _delegations[i]._numerator / DENOMINATOR)
+      );
       _totalNumerator += _delegations[i]._numerator;
     }
     if (_totalNumerator > DENOMINATOR) {

--- a/test/ERC20VotesPartialDelegationUpgradeable.t.sol
+++ b/test/ERC20VotesPartialDelegationUpgradeable.t.sol
@@ -662,7 +662,7 @@ contract Delegate is PartialDelegationTest {
     uint256 _seed
   ) public {
     vm.assume(_actor != address(0));
-    _amount = bound(_amount, 0, type(uint208).max);
+    _amount = bound(_amount, 0, type(uint200).max);
     PartialDelegation[] memory delegations = _createValidPartialDelegation(0, _seed);
     _delegationIndex = bound(_delegationIndex, 0, delegations.length - 1);
 


### PR DESCRIPTION
Fixes 8.1 and 8.2 edgm412bkcc8tp