### PR TITLE
Move initialization

### DIFF
--- a/src/ERC20VotesPartialDelegationUpgradeable.sol
+++ b/src/ERC20VotesPartialDelegationUpgradeable.sol
@@ -30,9 +30,19 @@ abstract contract ERC20VotesPartialDelegationUpgradeable is
    */
   error ERC20ExceededSafeSupply(uint256 increasedSupply, uint256 cap);
 
-  function __ERC20VotesPartialDelegation_init() internal onlyInitializing {}
+  function __ERC20VotesPartialDelegation_init(string calldata _name, string calldata _symbol) internal onlyInitializing {
+    __ERC20_init(_name, _symbol);
+    __EIP712_init(_name, "1");
+    __ERC20Permit_init(_name);
+    __VotesPartialDelegation_init();
+  }
 
-  function __ERC20VotesPartialDelegation_init_unchained() internal onlyInitializing {}
+  function __ERC20VotesPartialDelegation_init_unchained(string calldata _name, string calldata _symbol) internal onlyInitializing {
+    __ERC20_init(_name, _symbol);
+    __EIP712_init(_name, "1");
+    __ERC20Permit_init(_name);
+    __VotesPartialDelegation_init();
+  }
   /**
    * @dev Maximum token supply. Defaults to `type(uint208).max` (2^208^ - 1).
    *

--- a/src/ERC20VotesPartialDelegationUpgradeable.sol
+++ b/src/ERC20VotesPartialDelegationUpgradeable.sol
@@ -37,12 +37,8 @@ abstract contract ERC20VotesPartialDelegationUpgradeable is
     __VotesPartialDelegation_init();
   }
 
-  function __ERC20VotesPartialDelegation_init_unchained(string calldata _name, string calldata _symbol) internal onlyInitializing {
-    __ERC20_init(_name, _symbol);
-    __EIP712_init(_name, "1");
-    __ERC20Permit_init(_name);
-    __VotesPartialDelegation_init();
-  }
+  function __ERC20VotesPartialDelegation_init_unchained() internal onlyInitializing {}
+
   /**
    * @dev Maximum token supply. Defaults to `type(uint208).max` (2^208^ - 1).
    *
@@ -53,7 +49,6 @@ abstract contract ERC20VotesPartialDelegationUpgradeable is
    * additional logic requires it. When resolving override conflicts on this function, the minimum should be
    * returned.
    */
-
   function _maxSupply() internal view virtual returns (uint256) {
     return type(uint208).max;
   }

--- a/src/L2GovToken.sol
+++ b/src/L2GovToken.sol
@@ -26,11 +26,11 @@ contract L2GovToken is AccessControlUpgradeable, ERC20VotesPartialDelegationUpgr
    * @dev Reverts if the provided admin address is zero.
    */
   function initialize(address _admin, string calldata _name, string calldata _symbol) public initializer {
-    __ERC20VotesPartialDelegation_init(_name, _symbol);
-    __AccessControl_init();
     if (_admin == address(0)) {
       revert InvalidAddressZero();
     }
+    __ERC20VotesPartialDelegation_init(_name, _symbol);
+    __AccessControl_init();
     _grantRole(DEFAULT_ADMIN_ROLE, _admin);
   }
 

--- a/src/L2GovToken.sol
+++ b/src/L2GovToken.sol
@@ -26,11 +26,8 @@ contract L2GovToken is AccessControlUpgradeable, ERC20VotesPartialDelegationUpgr
    * @dev Reverts if the provided admin address is zero.
    */
   function initialize(address _admin, string calldata _name, string calldata _symbol) public initializer {
-    __ERC20_init(_name, _symbol);
-    __EIP712_init(_name, "1");
-    __ERC20Permit_init(_name);
+    __ERC20VotesPartialDelegation_init(_name, _symbol);
     __AccessControl_init();
-    __VotesPartialDelegation_init();
     if (_admin == address(0)) {
       revert InvalidAddressZero();
     }


### PR DESCRIPTION
Fixes 8.4 `initialize()` Should Call ERC20VotesPartialDelegationUpgradeable.__ERC20VotesPartialDelegation_init